### PR TITLE
fix: Added name field in pom generation

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.feature.publish-maven-repository.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-maven-repository.gradle.kts
@@ -67,6 +67,7 @@ publishing.publications.withType<MavenPublication>().configureEach {
                 .reader()
         )
 
+        name.set(project.name)
         url = "https://hiero.org/"
         inceptionYear = "2024"
 


### PR DESCRIPTION
**Description**: Updates the publish-maven-repository gradle file to include the project name. This is required for schema validation within maven central.

**Related Issue(s)**:
Fixes #3 