### PR TITLE
fix(bug): Update description setters

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.feature.publish-maven-repository.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-maven-repository.gradle.kts
@@ -75,9 +75,9 @@ publishing.publications.withType<MavenPublication>().configureEach {
             providers
                 .fileContents(layout.projectDirectory.file("../description.txt"))
                 .asText
-                .orElse(provider { project.description })
+                .orElse(provider(project::getDescription))
                 .map { it.replace("\n", " ").trim() }
-                .orNull
+                .orElse("")
 
         organization {
             name = "Hiero - a Linux Foundation Decentralized Trust project"


### PR DESCRIPTION
**Description**:

The `<description></description>` field was not present in the pom.xml file generated for maven central. Needed to update two parts of the field setter:

- `.orElse(provider { project.description })` became `.orElse(provider(project::getDescription))` to actually populate with the project description
- `.orNull()` becomes `.orElse("")` to prevent a null entry on description if it is not present in the other ways