### PR TITLE
chore: change Module Name to official name 'com.esaulpaugh.headlong'

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
@@ -143,7 +143,7 @@ extraJavaModuleInfo {
     module("io.perfmark:perfmark-api", "io.perfmark")
     module("javax.inject:javax.inject", "javax.inject")
     module("commons-codec:commons-codec", "org.apache.commons.codec")
-    module("com.esaulpaugh:headlong", "headlong")
+    module("com.esaulpaugh:headlong", "com.esaulpaugh.headlong")
     module("org.connid:framework", "org.connid.framework")
     module("org.connid:framework-internal", "org.connid.framework.internal") {
         exportAllPackages()


### PR DESCRIPTION
See: https://github.com/hashgraph/hedera-sdk-java/pull/2059#issuecomment-2488506421