### PR TITLE
build: always sign via useGpgCmd()

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,10 +106,8 @@ val publishSigningEnabled =
 
 if (publishSigningEnabled) {
     signing {
-        useInMemoryPgpKeys(
-            providers.environmentVariable("SIGNING_KEY").get(),
-            providers.environmentVariable("SIGNING_PASSPHRASE").get()
-        )
+        sign(publishing.publications)
+        useGpgCmd()
     }
 }
 

--- a/src/main/kotlin/org.hiero.gradle.feature.publish-maven-repository.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-maven-repository.gradle.kts
@@ -35,10 +35,6 @@ if (publishSigningEnabled) {
     signing {
         sign(publishing.publications)
         useGpgCmd()
-        useInMemoryPgpKeys(
-            providers.environmentVariable("SIGNING_KEY").get(),
-            providers.environmentVariable("SIGNING_PASSPHRASE").get()
-        )
     }
 }
 


### PR DESCRIPTION
See: https://github.com/hashgraph/hedera-services/issues/16548