### PR TITLE
chore: update license headers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     `kotlin-dsl`
     id("signing")
@@ -125,35 +110,17 @@ testing {
 }
 
 spotless {
-    val header =
-        """
-           /*
-            * Copyright (C) ${'$'}YEAR Hiero a Series of LF Projects, LLC
-            *
-            * Licensed under the Apache License, Version 2.0 (the "License");
-            * you may not use this file except in compliance with the License.
-            * You may obtain a copy of the License at
-            *
-            *      http://www.apache.org/licenses/LICENSE-2.0
-            *
-            * Unless required by applicable law or agreed to in writing, software
-            * distributed under the License is distributed on an "AS IS" BASIS,
-            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-            * See the License for the specific language governing permissions and
-            * limitations under the License.
-            */${"\n\n"}
-        """
-            .trimIndent()
-    val top =
+    val header = "// SPDX-License-Identifier: Apache-2.0\n"
+    val delimiter =
         "(import|package|plugins|pluginManagement|dependencyResolutionManagement|repositories|tasks|allprojects|subprojects|buildCache|version)"
 
     kotlinGradle {
         ktfmt().kotlinlangStyle()
-        licenseHeader(header, top).updateYearWithLatest(true)
+        licenseHeader(header, delimiter)
     }
     kotlin {
         ktfmt().kotlinlangStyle()
         targetExclude("build/**")
-        licenseHeader(header, top).updateYearWithLatest(true)
+        licenseHeader(header, delimiter)
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { id("com.gradle.develocity") version "3.18.2" }
 
 rootProject.name = "hiero-gradle-conventions"

--- a/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2016-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("org.gradlex.jvm-dependency-conflict-resolution")
     id("org.gradlex.extra-java-module-info")

--- a/src/main/kotlin/org.hiero.gradle.base.lifecycle.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.base.lifecycle.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2016-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { id("base") }
 
 // Convenience for local development: when running './gradlew' without any parameters show the tasks

--- a/src/main/kotlin/org.hiero.gradle.base.version.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.base.version.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2016-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 version =
     providers
         .fileContents(isolated.rootProject.projectDirectory.file("version.txt"))

--- a/src/main/kotlin/org.hiero.gradle.build.settings.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.build.settings.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import org.gradlex.javamodule.dependencies.initialization.JavaModulesExtension
 import org.gradlex.javamodule.dependencies.initialization.RootPluginsExtension
 

--- a/src/main/kotlin/org.hiero.gradle.check.dependencies.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.check.dependencies.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import com.autonomousapps.DependencyAnalysisExtension
 import com.autonomousapps.DependencyAnalysisSubExtension
 import org.gradlex.javamodule.dependencies.tasks.ModuleDirectivesOrderingCheck

--- a/src/main/kotlin/org.hiero.gradle.check.javac-lint.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.check.javac-lint.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { id("java") }
 
 val deactivatedCompileLintOptions =

--- a/src/main/kotlin/org.hiero.gradle.check.spotless-java.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.check.spotless-java.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import org.hiero.gradle.spotless.RepairDashedCommentsFormatterStep
 import org.hiero.gradle.spotless.SortModuleInfoRequiresStep
 
@@ -37,27 +22,6 @@ spotless {
         // through git history (see "license" section below).
         // The delimiter override below is required to support some
         // of our test classes which are in the default package.
-        licenseHeader(
-                """
-           /*
-            * Copyright (C) ${'$'}YEAR Hedera Hashgraph, LLC
-            *
-            * Licensed under the Apache License, Version 2.0 (the "License");
-            * you may not use this file except in compliance with the License.
-            * You may obtain a copy of the License at
-            *
-            *      http://www.apache.org/licenses/LICENSE-2.0
-            *
-            * Unless required by applicable law or agreed to in writing, software
-            * distributed under the License is distributed on an "AS IS" BASIS,
-            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-            * See the License for the specific language governing permissions and
-            * limitations under the License.
-            */${"\n\n"}
-        """
-                    .trimIndent(),
-                "(package|import|module)"
-            )
-            .updateYearWithLatest(true)
+        licenseHeader("// SPDX-License-Identifier: Apache-2.0\n", "(package|import|module)")
     }
 }

--- a/src/main/kotlin/org.hiero.gradle.check.spotless-kotlin.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.check.spotless-kotlin.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { id("com.diffplug.spotless") }
 
 spotless {
@@ -21,26 +6,8 @@ spotless {
         ktfmt().kotlinlangStyle()
 
         licenseHeader(
-                """
-           /*
-            * Copyright (C) ${'$'}YEAR Hedera Hashgraph, LLC
-            *
-            * Licensed under the Apache License, Version 2.0 (the "License");
-            * you may not use this file except in compliance with the License.
-            * You may obtain a copy of the License at
-            *
-            *      http://www.apache.org/licenses/LICENSE-2.0
-            *
-            * Unless required by applicable law or agreed to in writing, software
-            * distributed under the License is distributed on an "AS IS" BASIS,
-            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-            * See the License for the specific language governing permissions and
-            * limitations under the License.
-            */${"\n\n"}
-        """
-                    .trimIndent(),
-                "(import|plugins|pluginManagement|dependencyResolutionManagement|repositories|tasks|allprojects|subprojects|buildCache|version)"
-            )
-            .updateYearWithLatest(true)
+            "// SPDX-License-Identifier: Apache-2.0\n",
+            "(import|plugins|pluginManagement|dependencyResolutionManagement|repositories|tasks|allprojects|subprojects|buildCache|version)"
+        )
     }
 }

--- a/src/main/kotlin/org.hiero.gradle.check.spotless-markdown.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.check.spotless-markdown.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { id("com.diffplug.spotless") }
 
 spotless {

--- a/src/main/kotlin/org.hiero.gradle.check.spotless-misc.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.check.spotless-misc.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { id("com.diffplug.spotless") }
 
 spotless {

--- a/src/main/kotlin/org.hiero.gradle.check.spotless-yaml.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.check.spotless-yaml.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { id("com.diffplug.spotless") }
 
 spotless {
@@ -33,27 +18,6 @@ spotless {
         indentWithSpaces()
         endWithNewline()
 
-        licenseHeader(
-                """
-            ##
-            # Copyright (C) ${'$'}YEAR Hedera Hashgraph, LLC
-            #
-            # Licensed under the Apache License, Version 2.0 (the "License");
-            # you may not use this file except in compliance with the License.
-            # You may obtain a copy of the License at
-            #
-            #      http://www.apache.org/licenses/LICENSE-2.0
-            #
-            # Unless required by applicable law or agreed to in writing, software
-            # distributed under the License is distributed on an "AS IS" BASIS,
-            # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-            # See the License for the specific language governing permissions and
-            # limitations under the License.
-            ##${"\n\n"}
-        """
-                    .trimIndent(),
-                "(name)"
-            )
-            .updateYearWithLatest(true)
+        licenseHeader("# SPDX-License-Identifier: Apache-2.0\n", "(name)")
     }
 }

--- a/src/main/kotlin/org.hiero.gradle.check.spotless.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.check.spotless.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("org.hiero.gradle.base.lifecycle")
     id("com.diffplug.spotless")

--- a/src/main/kotlin/org.hiero.gradle.feature.antlr.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.antlr.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("java")
     id("antlr")

--- a/src/main/kotlin/org.hiero.gradle.feature.benchmark.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.benchmark.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import me.champeau.jmh.JMHTask
 
 plugins { id("me.champeau.jmh") }

--- a/src/main/kotlin/org.hiero.gradle.feature.build-cache.settings.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.build-cache.settings.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 buildCache {
     remote<HttpBuildCache> {
         url = uri("https://cache.gradle.hedera.svcs.eng.swirldslabs.io/cache/")

--- a/src/main/kotlin/org.hiero.gradle.feature.git-properties-file.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.git-properties-file.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { id("java") }
 
 tasks.register<WriteProperties>("writeGitProperties") {

--- a/src/main/kotlin/org.hiero.gradle.feature.java-compile.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.java-compile.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("java")
     id("org.gradlex.reproducible-builds")

--- a/src/main/kotlin/org.hiero.gradle.feature.java-doc.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.java-doc.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("java")
     id("org.gradlex.reproducible-builds")

--- a/src/main/kotlin/org.hiero.gradle.feature.java-execute.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.java-execute.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { id("java") }
 
 tasks.withType<JavaExec>().configureEach {

--- a/src/main/kotlin/org.hiero.gradle.feature.protobuf.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.protobuf.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2023-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("java")
     id("com.google.protobuf")

--- a/src/main/kotlin/org.hiero.gradle.feature.publish-artifactregistry.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-artifactregistry.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2023-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { id("maven-publish") }
 
 if (gradle.startParameter.taskNames.any { it.startsWith("release") }) {

--- a/src/main/kotlin/org.hiero.gradle.feature.publish-gradle-plugin-portal.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-gradle-plugin-portal.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2016-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("java")
     id("com.gradle.plugin-publish")

--- a/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2016-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("java")
     id("maven-publish")

--- a/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central.root.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central.root.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2023-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("org.hiero.gradle.base.lifecycle")
     id("io.github.gradle-nexus.publish-plugin")

--- a/src/main/kotlin/org.hiero.gradle.feature.publish-maven-repository.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-maven-repository.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2016-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import java.util.Properties
 
 plugins {

--- a/src/main/kotlin/org.hiero.gradle.feature.repositories.settings.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.repositories.settings.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2016-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {

--- a/src/main/kotlin/org.hiero.gradle.feature.rust.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.rust.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import org.hiero.gradle.extensions.CargoExtension
 import org.hiero.gradle.extensions.CargoToolchain.*
 import org.hiero.gradle.services.TaskLockService

--- a/src/main/kotlin/org.hiero.gradle.feature.test-fixtures.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.test-fixtures.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import org.gradle.api.component.AdhocComponentWithVariants
 
 plugins {

--- a/src/main/kotlin/org.hiero.gradle.feature.test-hammer.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.test-hammer.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import org.hiero.gradle.services.TaskLockService
 
 plugins { id("java") }

--- a/src/main/kotlin/org.hiero.gradle.feature.test-integration.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.test-integration.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { id("java") }
 
 // Tests that could be in the default "test" set but take more than 100ms to execute.

--- a/src/main/kotlin/org.hiero.gradle.feature.test-multios.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.test-multios.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { id("java") }
 
 tasks.test {

--- a/src/main/kotlin/org.hiero.gradle.feature.test-time-consuming.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.test-time-consuming.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { id("java") }
 
 // Tests that could be in the default "test" set but take more than 100ms to execute.

--- a/src/main/kotlin/org.hiero.gradle.feature.test-timing-sensitive.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.test-timing-sensitive.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import org.hiero.gradle.services.TaskLockService
 
 plugins { id("java") }

--- a/src/main/kotlin/org.hiero.gradle.feature.test.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.test.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import org.hiero.gradle.services.TaskLockService
 
 plugins { id("java") }

--- a/src/main/kotlin/org.hiero.gradle.feature.versioning.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.versioning.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2023-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import net.swiftzer.semver.SemVer
 
 val versionTxt = layout.projectDirectory.file("version.txt")

--- a/src/main/kotlin/org.hiero.gradle.module.application.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.module.application.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2016-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("application")
     id("jacoco")

--- a/src/main/kotlin/org.hiero.gradle.module.gradle-plugin.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.module.gradle-plugin.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("java-library")
     id("org.hiero.gradle.feature.publish-maven-repository")

--- a/src/main/kotlin/org.hiero.gradle.module.library.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.module.library.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("java-library")
     id("org.hiero.gradle.feature.publish-maven-repository")

--- a/src/main/kotlin/org.hiero.gradle.report.code-coverage.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.report.code-coverage.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2023-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import org.gradlex.javamodule.dependencies.tasks.ModuleDirectivesScopeCheck
 
 plugins {

--- a/src/main/kotlin/org.hiero.gradle.report.develocity.settings.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.report.develocity.settings.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { id("com.gradle.develocity") }
 
 develocity {

--- a/src/main/kotlin/org.hiero.gradle.report.test-logger.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.report.test-logger.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import com.adarshr.gradle.testlogger.theme.ThemeType
 
 plugins { id("com.adarshr.test-logger") }

--- a/src/main/kotlin/org/hiero/gradle/extensions/CargoExtension.kt
+++ b/src/main/kotlin/org/hiero/gradle/extensions/CargoExtension.kt
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package org.hiero.gradle.extensions
 
 import javax.inject.Inject

--- a/src/main/kotlin/org/hiero/gradle/extensions/CargoToolchain.kt
+++ b/src/main/kotlin/org/hiero/gradle/extensions/CargoToolchain.kt
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package org.hiero.gradle.extensions
 
 enum class CargoToolchain(val platform: String, val target: String, val folder: String) {

--- a/src/main/kotlin/org/hiero/gradle/services/TaskLockService.kt
+++ b/src/main/kotlin/org/hiero/gradle/services/TaskLockService.kt
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package org.hiero.gradle.services
 
 import org.gradle.api.services.BuildService

--- a/src/main/kotlin/org/hiero/gradle/spotless/RepairDashedCommentsFormatterStep.kt
+++ b/src/main/kotlin/org/hiero/gradle/spotless/RepairDashedCommentsFormatterStep.kt
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package org.hiero.gradle.spotless
 
 import com.diffplug.spotless.FormatterFunc

--- a/src/main/kotlin/org/hiero/gradle/spotless/SortModuleInfoRequiresStep.kt
+++ b/src/main/kotlin/org/hiero/gradle/spotless/SortModuleInfoRequiresStep.kt
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package org.hiero.gradle.spotless
 
 import com.diffplug.spotless.FormatterFunc

--- a/src/main/kotlin/org/hiero/gradle/tasks/CargoBuildTask.kt
+++ b/src/main/kotlin/org/hiero/gradle/tasks/CargoBuildTask.kt
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package org.hiero.gradle.tasks
 
 import java.io.File

--- a/src/main/kotlin/org/hiero/gradle/tasks/GitClone.kt
+++ b/src/main/kotlin/org/hiero/gradle/tasks/GitClone.kt
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package org.hiero.gradle.tasks
 
 import javax.inject.Inject

--- a/src/test/kotlin/org/hiero/gradle/test/ConventionPluginTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/ConventionPluginTest.kt
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package org.hiero.gradle.test
 
 import java.io.File

--- a/src/test/kotlin/org/hiero/gradle/test/QualityCheckTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/QualityCheckTest.kt
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package org.hiero.gradle.test
 
 import org.assertj.core.api.Assertions.assertThat

--- a/src/test/kotlin/org/hiero/gradle/test/fixtures/GradleProject.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/fixtures/GradleProject.kt
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hiero a Series of LF Projects, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package org.hiero.gradle.test.fixtures
 
 import java.io.File
@@ -45,25 +30,7 @@ class GradleProject {
     private val javaSourceFile =
         file("product/module-a/src/main/java/org/hiero/product/module/a/ModuleA.java")
 
-    private val expectedHeader =
-        """
-           /*
-            * Copyright (C) 2024 Hedera Hashgraph, LLC
-            *
-            * Licensed under the Apache License, Version 2.0 (the "License");
-            * you may not use this file except in compliance with the License.
-            * You may obtain a copy of the License at
-            *
-            *      http://www.apache.org/licenses/LICENSE-2.0
-            *
-            * Unless required by applicable law or agreed to in writing, software
-            * distributed under the License is distributed on an "AS IS" BASIS,
-            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-            * See the License for the specific language governing permissions and
-            * limitations under the License.
-            */
-    """
-            .trimIndent()
+    private val expectedHeader = "// SPDX-License-Identifier: Apache-2.0\n"
 
     fun withMinimalStructure(): GradleProject {
         gradlePropertiesFile.writeText(
@@ -137,7 +104,7 @@ class GradleProject {
     fun failQualityCheck(): BuildResult = runner(listOf("qualityCheck")).buildAndFail()
 
     private fun File.writeFormatted(content: String) {
-        writeText("$expectedHeader\n\n$content\n")
+        writeText("$expectedHeader$content\n")
     }
 
     private fun runner(args: List<String>) =


### PR DESCRIPTION
This PR updates the license headers as defined in
https://github.com/hiero-ledger/hiero/pull/26

It updates:
- The headers in the files in this repository
- The header spotless rules to update the headers in the repositories that are going to use these plugins