### PR TITLE
chore: Update actions and runs-on stanzas.

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   plugin-portal-release:
     name: Release Gradle Plugin Portal
-    runs-on: hiero-client-sdk-linux-medium
+    runs-on: hiero-network-node-linux-medium
     steps:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -46,7 +46,7 @@ jobs:
 
       - name: Import GPG key
         id: gpg_key
-        uses: step-security/ghaction-import-gpg@6c8fe4d0126a59d57c21f87c9ae5dd3451fa3cca # v6.1.0
+        uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
         with:
           gpg_private_key: ${{ secrets.GPG_KEY_CONTENTS }}
           passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}

--- a/.github/workflows/zxc-build-plugins.yaml
+++ b/.github/workflows/zxc-build-plugins.yaml
@@ -21,8 +21,7 @@ env:
 jobs:
   compile:
     name: Compile and Test
-#    runs-on: network-node-linux-medium
-    runs-on: ubuntu-latest
+    runs-on: hiero-network-node-linux-medium
     steps:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -46,9 +45,9 @@ jobs:
       - name: Code Quality Checks and Tests
         run: ./gradlew check --scan
 
-#      - name: Publish JUnit Test Report
-#        uses: step-security/publish-unit-test-result-action@4519d7c9f71dd765f8bbb98626268780f23bab28 # v2.17.0
-#        with:
-#          check_name: JUnit Test Report
-#          time_unit: seconds
-#          junit_files: "build/test-results/**/*.xml"
+      - name: Publish JUnit Test Report
+        uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
+        with:
+          check_name: JUnit Test Report
+          time_unit: seconds
+          junit_files: "build/test-results/**/*.xml"


### PR DESCRIPTION
**Description**:
Updates workflows to avoid step-security maintained actions as we don't have a license configured with them yet.

Configured a hiero-ledger version of the network-node runners

Moved runners from gh hosted to self-hosted

**Related Issue(s)**:
Fixes #23