### PR TITLE
build: fix issue caused by interaction with releasePrereleaseChannel and publish-artifactregistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hiero Gradle Conventions - Changelog
 
+## Version 0.1.4
+
+* fix issue caused by interaction between 'publish-prerelease-channel' and 'publish-artifactregistry' (#55)
+
 ## Version 0.1.3
 
 * fix issue caused by interaction between 'publish-maven-central' and 'publish-artifactregistry' (#54)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 0.1.4
 
-* fix issue caused by interaction between 'publish-prerelease-channel' and 'publish-artifactregistry' (#55)
+* fix issue caused by interaction between 'releasePrereleaseChannel' and 'publish-artifactregistry' (#55)
 
 ## Version 0.1.3
 

--- a/src/main/kotlin/org.hiero.gradle.feature.publish-artifactregistry.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-artifactregistry.gradle.kts
@@ -2,7 +2,8 @@
 plugins { id("maven-publish") }
 
 if (
-    gradle.startParameter.taskNames.any { it.startsWith("release") && !it.contains("MavenCentral") }
+    gradle.startParameter.taskNames.any { it.startsWith("release") && !it.contains("MavenCentral") &&
+            !it.contains("PrereleaseChannel") }
 ) {
     // We apply the 'artifactregistry' plugin conditionally, as it does not support configuration
     // cache.

--- a/src/main/kotlin/org.hiero.gradle.feature.publish-artifactregistry.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-artifactregistry.gradle.kts
@@ -2,15 +2,14 @@
 plugins { id("maven-publish") }
 
 if (
-    gradle.startParameter.taskNames.any {
-        it.startsWith("release") &&
-            !it.contains("MavenCentral") &&
-            !it.contains("PrereleaseChannel")
-    }
+    gradle.startParameter.taskNames.any { it.startsWith("release") && !it.contains("MavenCentral") }
 ) {
-    // We apply the 'artifactregistry' plugin conditionally, as it does not support configuration
-    // cache.
-    // https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools/issues/85
+    // We apply the 'artifactregistry' plugin conditionally, as there are two issues:
+    // 1. It does not support configuration cache.
+    //    https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools/issues/85
+    // 2. It does not interact well with the 'gradle-nexus.publish-plugin' plugin, causing:
+    //    'No staging repository with name sonatype created' during IDE import
+    publishing.repositories.remove(publishing.repositories.getByName("sonatype"))
     apply(plugin = "com.google.cloud.artifactregistry.gradle-plugin")
 }
 

--- a/src/main/kotlin/org.hiero.gradle.feature.publish-artifactregistry.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-artifactregistry.gradle.kts
@@ -2,8 +2,11 @@
 plugins { id("maven-publish") }
 
 if (
-    gradle.startParameter.taskNames.any { it.startsWith("release") && !it.contains("MavenCentral") &&
-            !it.contains("PrereleaseChannel") }
+    gradle.startParameter.taskNames.any {
+        it.startsWith("release") &&
+            !it.contains("MavenCentral") &&
+            !it.contains("PrereleaseChannel")
+    }
 ) {
     // We apply the 'artifactregistry' plugin conditionally, as it does not support configuration
     // cache.


### PR DESCRIPTION
**Description**:

There was an issue where releasePrereleaseChannel was attempting to use the artifactregistry plugin when it should not. The resolution is to add a condition to an if-check to resolve this issue.

**Related Issue(s)**:

Fixes #55