### PR TITLE
build: add patch rule for 'com.squareup:kotlinpoet-jvm'

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
@@ -40,6 +40,10 @@ jvmDependencyConflicts.patch {
     }
     module("com.google.dagger:dagger-compiler") {
         annotationLibraries.forEach { removeDependency(it) }
+        // Depend directly on 'kotlinpoet-jvm' as 'kotlinpoet' just contain Kotlin Multiplatform
+        // metadata that we do not need and that is not a Java Module
+        removeDependency("com.squareup:kotlinpoet")
+        addApiDependency("com.squareup:kotlinpoet-jvm")
     }
     module("com.google.dagger:dagger-producers") {
         annotationLibraries.forEach { removeDependency(it) }
@@ -67,7 +71,7 @@ jvmDependencyConflicts.patch {
     module("junit:junit") { removeDependency("org.hamcrest:hamcrest-core") }
     module("org.hyperledger.besu:secp256k1") { addApiDependency("net.java.dev.jna:jna") }
     module("com.squareup.okhttp3:okhttp") {
-        // Depend directly on 'okio-jvm' as 'okio' just contain Kotlin Mulitplatform metadata that
+        // Depend directly on 'okio-jvm' as 'okio' just contain Kotlin Multiplatform metadata that
         // we do not need and that is not a Java Module
         removeDependency("com.squareup.okio:okio")
         addApiDependency("com.squareup.okio:okio-jvm")
@@ -135,6 +139,7 @@ extraJavaModuleInfo {
     module("com.google.guava:failureaccess", "com.google.common.util.concurrent.internal")
     module("com.google.api.grpc:proto-google-common-protos", "com.google.api.grpc.common")
     module("com.google.dagger:dagger", "dagger")
+    module("com.squareup:kotlinpoet-jvm", "com.squareup.kotlinpoet")
     module("com.squareup.okhttp3:okhttp", "okhttp3")
     module("com.squareup.okio:okio-jvm", "okio")
     module("io.perfmark:perfmark-api", "io.perfmark")

--- a/src/test/kotlin/org/hiero/gradle/test/JpmsPatchTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/JpmsPatchTest.kt
@@ -32,7 +32,6 @@ class JpmsPatchTest {
             dependencies.constraints {
                 modules.forEach {  api("${'$'}it:latest.release") }
                 api("org.jetbrains:annotations:latest.release")
-                api("com.google.dagger:dagger-compiler:2.42!!")
                 api("org.hyperledger.besu:evm:24.3.3!!")
             }
         """


### PR DESCRIPTION
This is used by the latest Dagger version.