### PR TITLE
build: deactivate signing by default for everything that is published

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.feature.publish-maven-repository.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-maven-repository.gradle.kts
@@ -15,11 +15,11 @@ java {
 val publishSigningEnabled =
     providers.gradleProperty("publishSigningEnabled").getOrElse("false").toBoolean()
 
-if (publishSigningEnabled) {
-    signing {
-        sign(publishing.publications)
-        useGpgCmd()
-    }
+tasks.withType<Sign>().configureEach { enabled = publishSigningEnabled }
+
+signing {
+    sign(publishing.publications)
+    useGpgCmd()
 }
 
 publishing.publications.withType<MavenPublication>().configureEach {

--- a/src/test/kotlin/org/hiero/gradle/test/LocalPublishTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/LocalPublishTest.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.gradle.test
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome
+import org.hiero.gradle.test.fixtures.GradleProject
+import org.junit.jupiter.api.Test
+
+class LocalPublishTest {
+
+    @Test
+    fun `can perform a local publish of library without signing keys`() {
+        val p = GradleProject().withMinimalStructure()
+        p.moduleBuildFile("""plugins { id("org.hiero.gradle.module.library") }""")
+
+        val result = p.run("publishToMavenLocal -Dmaven.repo.local=${p.file(".m2").absolutePath}")
+
+        assertThat(result.task(":module-a:publishMavenPublicationToMavenLocal")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(p.file(".m2/org/example/module-a/1.0/module-a-1.0.jar")).exists()
+    }
+
+    @Test
+    fun `can perform a local publish of gradle plugin without signing keys`() {
+        val p = GradleProject().withMinimalStructure()
+        p.moduleBuildFile("""plugins { id("org.hiero.gradle.module.gradle-plugin") }""")
+
+        val result = p.run("publishToMavenLocal -Dmaven.repo.local=${p.file(".m2").absolutePath}")
+
+        assertThat(result.task(":module-a:publishPluginMavenPublicationToMavenLocal")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(p.file(".m2/org/example/module-a/1.0/module-a-1.0.jar")).exists()
+    }
+}

--- a/src/test/kotlin/org/hiero/gradle/test/MavenCentralPublishTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/MavenCentralPublishTest.kt
@@ -18,7 +18,7 @@ class MavenCentralPublishTest {
                 id("org.hiero.gradle.feature.publish-artifactregistry")
             }
           """
-                .trimMargin()
+                .trimIndent()
         )
 
         // We should not get: 'No staging repository with name sonatype created'

--- a/src/test/kotlin/org/hiero/gradle/test/PublishDependencyConstraintsTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/PublishDependencyConstraintsTest.kt
@@ -31,7 +31,7 @@ class PublishDependencyConstraintsTest {
                 publishDependencyConstraint("io.grpc:grpc-netty")
             }
           """
-                .trimMargin()
+                .trimIndent()
         )
 
         p.run("generateMetadataFileForMavenPublication")


### PR DESCRIPTION
...including Gradle plugins, for which '-PpublishSigningEnabled' had no effect.