### PR TITLE
chore: Bring in animal-sniffer-annotations

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
@@ -42,7 +42,6 @@ jvmDependencyConflicts.patch {
             "com.google.guava:listenablefuture",
             "org.checkerframework:checker-compat-qual",
             "org.checkerframework:checker-qual",
-            "org.codehaus.mojo:animal-sniffer-annotations",
         )
 
     module("io.netty:netty-transport-native-epoll") {


### PR DESCRIPTION
https://github.com/hiero-ledger/hiero-sdk-java/pull/2224 relates to this PR where we are updating grpc version from 1.69.1  to 1.70.0.

