### PR TITLE
build: add patching rules for 'org.hyperledger.besu.nativelib.gnark'

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
@@ -228,7 +228,10 @@ extraJavaModuleInfo {
     module("org.hyperledger.besu:gnark", "org.hyperledger.besu.nativelib.gnark")
     module("com.goterl:resource-loader", "resource.loader")
     module("com.goterl:lazysodium-java", "lazysodium.java")
+    // 'io.consensys.protocols' replaces 'tech.pegasys' in org.hyperledger.besu:evm:25.x
+    // once 24.x is no longer used, 'tech.pegasys' rule can be removed.
     module("tech.pegasys:jc-kzg-4844", "tech.pegasys.jckzg4844")
+    module("io.consensys.protocols:jc-kzg-4844", "io.consensys.protocols.jckzg4844")
     module("net.java.dev.jna:jna", "com.sun.jna") {
         exportAllPackages()
         requires("java.logging")

--- a/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
@@ -221,6 +221,7 @@ extraJavaModuleInfo {
     }
     module("org.hyperledger.besu:secp256k1", "org.hyperledger.besu.nativelib.secp256k1")
     module("org.hyperledger.besu:secp256r1", "org.hyperledger.besu.nativelib.secp256r1")
+    module("org.hyperledger.besu:gnark", "org.hyperledger.besu.nativelib.gnark")
     module("com.goterl:resource-loader", "resource.loader")
     module("com.goterl:lazysodium-java", "lazysodium.java")
     module("tech.pegasys:jc-kzg-4844", "tech.pegasys.jckzg4844")

--- a/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
@@ -19,6 +19,9 @@ val additionalTransitiveCompileOnlyApiDependencies =
 // Fix or enhance the metadata of third-party Modules. This is about the metadata in the
 // repositories: '*.pom' and '*.module' files.
 jvmDependencyConflicts.patch {
+    // Workaround for: https://github.com/hyperledger/besu/pull/8443
+    module("org.hyperledger.besu:bom") { removeDependency("javax.inject:javax.inject") }
+
     // Make annotation classes used by 'log4j' avaliable at compile time
     module("org.apache.logging.log4j:log4j-api") {
         additionalTransitiveCompileOnlyApiDependencies.forEach { addCompileOnlyApiDependency(it) }

--- a/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
@@ -214,6 +214,7 @@ extraJavaModuleInfo {
     module("org.hyperledger.besu:blake2bf", "org.hyperledger.besu.nativelib.blake2bf")
     module("org.hyperledger.besu:bls12-381", "org.hyperledger.besu.nativelib.bls12_381")
     module("org.hyperledger.besu:besu-datatypes", "org.hyperledger.besu.datatypes")
+    module("org.hyperledger.besu:besu-native-common", "org.hyperledger.besu.nativelib.common")
     module("org.hyperledger.besu:evm", "org.hyperledger.besu.evm") {
         exportAllPackages()
         requireAllDefinedDependencies()

--- a/src/test/kotlin/org/hiero/gradle/test/JpmsPatchTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/JpmsPatchTest.kt
@@ -34,7 +34,6 @@ class JpmsPatchTest {
                 api("org.jetbrains:annotations:latest.release")
                 api("org.mockito:mockito-core:latest.release")
                 api("org.mockito:mockito-junit-jupiter:latest.release")
-                api("org.hyperledger.besu:evm:24.3.3!!")
             }
         """
                 .trimIndent()
@@ -46,6 +45,7 @@ class JpmsPatchTest {
                 id("org.hiero.gradle.base.jpms-modules")
             }
             val modules = extraJavaModuleInfo.moduleSpecs.get().values.map { it.moduleName }.distinct()
+                .filter { it != "tech.pegasys.jckzg4844" }
             file("src/main/java/module-info.java").writeText(
                 "module org.example.module.a {\n${'$'}{modules.joinToString("") { "  requires ${'$'}it;\n"}}\n}")
             $versionPatching


### PR DESCRIPTION
**Description**:
With version 24.7.1 besu introduced new dependency of org.hyperledger.besu.nativelib.gnark so we need to include that module.

**Related issue(s)**:

Fixes #
[#17572](https://github.com/hiero-ledger/hiero-consensus-node/issues/17572)



**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
