### PR TITLE
ci: replace action with step-security maintained version

### DIFF
--- a/.github/workflows/zxc-build-plugins.yaml
+++ b/.github/workflows/zxc-build-plugins.yaml
@@ -47,7 +47,7 @@ jobs:
         run: ./gradlew check
 
       - name: Publish JUnit Test Report
-        uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # v2.18.0
+        uses: step-security/publish-unit-test-result-action@cc82caac074385ae176d39d2d143ad05e1130b2d # v2.18.0
         if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           check_name: JUnit Test Report


### PR DESCRIPTION
**Description**:
Replaced EnricoMi/publish-unit-test-result-action with step-security version

**Related issue(s)**:

Fixes #155 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
