### PR TITLE
build: remove Netty patch rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Hiero Gradle Conventions - Changelog
 
+## Version 0.4.0
+
+* JPMS - remove patching rules: io.netty
+
 ## Version 0.3.10
 
 * JPMS - extend module patching rules to obtain working runtime modules

--- a/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
@@ -104,27 +104,6 @@ extraJavaModuleInfo {
     failOnAutomaticModules = true // Only allow Jars with 'module-info' on all module paths
     versionsProvidingConfiguration = "mainRuntimeClasspath"
 
-    // WORKAROUND: https://github.com/netty/netty/issues/15003
-    module("io.netty:netty-codec-marshalling", "io.netty.codec.marshalling") {
-        patchRealModule()
-        requires("io.netty.buffer")
-        requires("io.netty.codec")
-        requires("io.netty.common")
-        requires("io.netty.transport")
-        requiresStatic("jboss.marshalling")
-        exports("io.netty.handler.codec.marshalling")
-    }
-    module("io.netty:netty-codec-protobuf", "io.netty.codec.protobuf") {
-        patchRealModule()
-        requires("io.netty.buffer")
-        requires("io.netty.codec")
-        requires("io.netty.common")
-        requires("io.netty.transport")
-        requiresStatic("com.google.protobuf")
-        requiresStatic("protobuf.javanano")
-        exports("io.netty.handler.codec.protobuf")
-    }
-
     // WORKAROUND: https://github.com/apache/logging-log4j2/issues/3437
     module("org.apache.logging.log4j:log4j-api", "org.apache.logging.log4j") {
         preserveExisting()

--- a/src/test/kotlin/org/hiero/gradle/test/JpmsPatchTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/JpmsPatchTest.kt
@@ -52,9 +52,7 @@ class JpmsPatchTest {
             val modules = extraJavaModuleInfo.moduleSpecs.get().values.map { it.moduleName }.distinct().filter { it !in listOf(
                 "tech.pegasys.jckzg4844",
                 "org.hyperledger.besu.nativelib.bls12_381",
-                "org.hyperledger.besu.nativelib.common",
-                "io.netty.codec.marshalling", // no direct dependency to keep excludes
-                "io.netty.codec.protobuf", // no direct dependency to keep excludes
+                "org.hyperledger.besu.nativelib.common"
             ) }
             file("src/main/java/module-info.java").writeText(
                 "module org.example.module.a {\n${'$'}{modules.joinToString("") { "  requires ${'$'}it;\n"}}\n}")


### PR DESCRIPTION
**Description**:
- The way we did it was not really the right solution (see discussion in https://github.com/netty/netty/issues/15003)
- The problem has been resolved in Netty `4.2.1.Final` - hence we remove the rule altogether
