### PR TITLE
build: add com.gradleup.nmcp for Maven Central publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,18 +218,19 @@ To perform the actual publishing use one of the following.
 (If multiple _products_ with different _groups_ should be published, the `releaseMavenCentral` task needs to run
 multiple times with different values for the `publishingPackageGroup` parameter.)
 
-|                                    Task and Parameters                                    |              Description               |
-|-------------------------------------------------------------------------------------------|----------------------------------------|
-| `./gradlew releaseMavenCentral -PpublishingPackageGroup=<group> --no-configuration-cache` | Publish artifacts to Maven central     |
-| `./gradlew publishPlugins --no-configuration-cache`                                       | Publish plugin to Gradle plugin portal |
+|                                    Task and Parameters                                    |                   Description                   |
+|-------------------------------------------------------------------------------------------|-------------------------------------------------|
+| `./gradlew releaseMavenCentral publishAggregationToCentralPortal`                         | Publish artifacts to Maven central (new Portal) |
+| `./gradlew releaseMavenCentral -PpublishingPackageGroup=<group> --no-configuration-cache` | Publish artifacts to Maven central (old OSSRH)  |
+| `./gradlew publishPlugins --no-configuration-cache`                                       | Publish plugin to Gradle plugin portal          |
 
 The following parameters may be used to tune or test the publishing (default is `false` for all parameters).
 
-|           Task and Parameters           |                     Description                     |
-|-----------------------------------------|-----------------------------------------------------|
-| `-PpublishSigningEnabled=<true\|false>` | Set to `true` for actual publishing                 |
-| `-Ps01SonatypeHost=<true\|false>`       | Use the `s01.oss.sonatype.org` host if required     |
-| `-PpublishTestRelease=<true\|false>`    | `false` - auto-release from staging when successful |
+|           Task and Parameters           |                         Description                         |
+|-----------------------------------------|-------------------------------------------------------------|
+| `-PpublishSigningEnabled=<true\|false>` | Set to `true` for actual publishing                         |
+| `-PpublishTestRelease=<true\|false>`    | `false` - auto-release from staging when successful         |
+| `-Ps01SonatypeHost=<true\|false>`       | Use the `s01.oss.sonatype.org` host if required (old OSSRH) |
 
 The following environment variables should be populated from _secrets_ to ensure a fully functional build.
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ multiple times with different values for the `publishingPackageGroup` parameter.
 
 |                                    Task and Parameters                                    |                   Description                   |
 |-------------------------------------------------------------------------------------------|-------------------------------------------------|
-| `./gradlew releaseMavenCentral publishAggregationToCentralPortal`                         | Publish artifacts to Maven central (new Portal) |
+| `./gradlew publishAggregationToCentralPortal`                                             | Publish artifacts to Maven central (new Portal) |
 | `./gradlew releaseMavenCentral -PpublishingPackageGroup=<group> --no-configuration-cache` | Publish artifacts to Maven central (old OSSRH)  |
 | `./gradlew publishPlugins --no-configuration-cache`                                       | Publish plugin to Gradle plugin portal          |
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation("com.google.protobuf:protobuf-gradle-plugin:0.9.5")
     implementation("com.gradle.publish:plugin-publish-plugin:1.3.1")
     implementation("com.gradle:develocity-gradle-plugin:4.0.1")
+    implementation("com.gradleup.nmcp:nmcp:0.1.2")
     implementation("com.gradleup.shadow:shadow-gradle-plugin:8.3.6")
     implementation(
         "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.2.2"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     implementation("com.google.protobuf:protobuf-gradle-plugin:0.9.5")
     implementation("com.gradle.publish:plugin-publish-plugin:1.3.1")
     implementation("com.gradle:develocity-gradle-plugin:4.0.1")
-    implementation("com.gradleup.nmcp:nmcp:0.1.2")
+    implementation("com.gradleup.nmcp:nmcp:0.1.4")
     implementation("com.gradleup.shadow:shadow-gradle-plugin:8.3.6")
     implementation(
         "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.2.2"

--- a/src/main/descriptions/org.hiero.gradle.feature.publish-maven-central-aggregation.txt
+++ b/src/main/descriptions/org.hiero.gradle.feature.publish-maven-central-aggregation.txt
@@ -1,0 +1,1 @@
+Conventions for 'com.gradleup.nmcp.aggregation' to publish all modules in an aggregated zip to the Maven Central Portal

--- a/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central-aggregation.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central-aggregation.gradle.kts
@@ -16,10 +16,6 @@ val nonSnapshotRelease = !version.toString().endsWith("-SNAPSHOT")
 configurations {
     val published = dependencyScope("published")
     this.implementation { extendsFrom(published.get()) }
-    this.nmcpAggregation {
-        extendsFrom(published.get())
-        isTransitive = false
-    }
     resolvable("transitiveNmcpAggregation") {
         extendsFrom(published.get())
         attributes {
@@ -33,9 +29,6 @@ tasks.zipAggregation {
     enabled = nonSnapshotRelease
 
     val archiveOperations = serviceOf<ArchiveOperations>()
-
-    // Requires adjustment in plugin to simplify: https://github.com/GradleUp/nmcp/issues/61
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     from(
         configurations["transitiveNmcpAggregation"]
             .incoming

--- a/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central-aggregation.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central-aggregation.gradle.kts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+import org.gradle.kotlin.dsl.support.serviceOf
+
+plugins {
+    id("java")
+    id("org.hiero.gradle.base.lifecycle")
+    id("org.hiero.gradle.base.version")
+    id("org.hiero.gradle.base.jpms-modules")
+    id("com.gradleup.nmcp.aggregation")
+}
+
+// In case of SNAPSHOT, do nothing as the upload is done directly by each module individually
+val nonSnapshotRelease = !version.toString().endsWith("-SNAPSHOT")
+
+@Suppress("UnstableApiUsage")
+configurations {
+    val published = dependencyScope("published")
+    this.implementation { extendsFrom(published.get()) }
+    this.nmcpAggregation {
+        extendsFrom(published.get())
+        isTransitive = false
+    }
+    resolvable("transitiveNmcpAggregation") {
+        extendsFrom(published.get())
+        attributes {
+            attribute(Attribute.of("com.gradleup.nmcp", Named::class.java), objects.named("bundle"))
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named("nmcp"))
+        }
+    }
+}
+
+tasks.zipAggregation {
+    enabled = nonSnapshotRelease
+
+    val archiveOperations = serviceOf<ArchiveOperations>()
+
+    // Requires adjustment in plugin to simplify: https://github.com/GradleUp/nmcp/issues/61
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    from(
+        configurations["transitiveNmcpAggregation"]
+            .incoming
+            .artifactView {
+                this.lenient(true)
+                this.componentFilter { it is ProjectComponentIdentifier }
+            }
+            .files
+            .elements
+            .map { it.map { zip -> archiveOperations.zipTree(zip) } }
+    )
+}
+
+nmcpAggregation {
+    // a 'test release' will be uploaded, but not automatically released
+    val publishTestRelease =
+        providers.gradleProperty("publishTestRelease").getOrElse("false").toBoolean()
+    centralPortal {
+        username = providers.environmentVariable("NEXUS_USERNAME")
+        password = providers.environmentVariable("NEXUS_PASSWORD")
+        publishingType = if (publishTestRelease) "USER_MANAGED" else "AUTOMATIC"
+    }
+}
+
+tasks.publishAggregationToCentralPortal {
+    enabled = nonSnapshotRelease
+    group = "release"
+}

--- a/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central.gradle.kts
@@ -1,17 +1,38 @@
 // SPDX-License-Identifier: Apache-2.0
 plugins {
+    id("org.hiero.gradle.base.lifecycle")
+    id("org.hiero.gradle.base.version")
     id("java")
     id("maven-publish")
-    id("org.hiero.gradle.base.lifecycle")
+    id("com.gradleup.nmcp")
+}
+
+val newPublishing = gradle.startParameter.taskNames.contains("publishAggregationToCentralPortal")
+
+configurations.nmcpProducer {
+    extendsFrom(configurations.implementation.get())
+    extendsFrom(configurations.runtimeOnly.get())
 }
 
 tasks.withType<PublishToMavenRepository>().configureEach {
     // Publishing tasks are only enabled if we publish to the matching group.
     // Otherwise, Nexus configuration and credentials do not fit.
     val publishingPackageGroup = providers.gradleProperty("publishingPackageGroup").orNull
-    enabled = publishingPackageGroup == project.group
+    enabled = newPublishing || publishingPackageGroup == project.group
 }
 
 publishing.publications.create<MavenPublication>("maven") { from(components["java"]) }
 
 tasks.named("releaseMavenCentral") { dependsOn(tasks.named("publishToSonatype")) }
+
+// Snapshots are published directly to Sonatype and not to a local folder first.
+// https://github.com/GradleUp/nmcp/issues/61
+if (version.toString().endsWith("-SNAPSHOT")) {
+    publishing.repositories.named<MavenArtifactRepository>("nmcpMaven") {
+        url = uri("https://central.sonatype.com/repository/maven-snapshots")
+        credentials {
+            username = providers.environmentVariable("NEXUS_USERNAME").orNull
+            password = providers.environmentVariable("NEXUS_PASSWORD").orNull
+        }
+    }
+}

--- a/src/test/kotlin/org/hiero/gradle/test/MavenCentralPortalPublishTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/MavenCentralPortalPublishTest.kt
@@ -81,7 +81,7 @@ class MavenCentralPortalPublishTest {
             dependencies { published(project(":module-a")) }
             tasks.publishAggregationToCentralPortal {
                 actions.clear()
-                doLast { println("publicationType=" + inputs.properties["publicationType"]) }
+                doLast { println("publishingType=" + inputs.properties["publishingType"]) }
             }
         """
         )
@@ -99,7 +99,7 @@ class MavenCentralPortalPublishTest {
             .isEqualTo(TaskOutcome.SUCCESS)
         assertThat(result.task(":aggregation:zipAggregation")?.outcome)
             .isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(result.output).contains("publicationType=USER_MANAGED")
+        assertThat(result.output).contains("publishingType=USER_MANAGED")
     }
 
     @Test

--- a/src/test/kotlin/org/hiero/gradle/test/MavenCentralPortalPublishTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/MavenCentralPortalPublishTest.kt
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.gradle.test
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome
+import org.hiero.gradle.test.fixtures.GradleProject
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class MavenCentralPortalPublishTest {
+
+    lateinit var p: GradleProject
+
+    @BeforeEach
+    fun setup() {
+        p = GradleProject().withMinimalStructure()
+        p.withEnv(mapOf("NEXUS_USERNAME" to "foo", "NEXUS_PASSWORD" to "bar"))
+        p.aggregationBuildFile(
+            """
+            plugins { id("org.hiero.gradle.feature.publish-maven-central-aggregation") }
+            dependencies { published(project(":module-a")) }
+        """
+        )
+        p.moduleBuildFile("""plugins { id("org.hiero.gradle.module.library") }""")
+    }
+
+    @Test
+    fun `attempts to upload a single archive for non-snapshot releases`() {
+        val result = p.runAndFail("publishAggregationToCentralPortal")
+
+        // Creates the publication zip, but fails to upload due to bad credentials
+        assertThat(
+                p.file(
+                    "product/module-a/build/nmcp/m2Maven/org/example/module-a/1.0/module-a-1.0.jar"
+                )
+            )
+            .exists()
+        assertThat(
+                p.file(
+                    "product/module-a/build/nmcp/m2Maven/org/example/module-a/1.0/module-a-1.0.module"
+                )
+            )
+            .exists()
+        assertThat(result.output)
+            .contains(
+                "> Cannot deploy to maven central (status='401'): {\"error\":{\"message\":\"Invalid token\"}}"
+            )
+        assertThat(result.task(":module-a:zipMavenPublication")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.task(":aggregation:publishAggregationToCentralPortal")?.outcome)
+            .isEqualTo(TaskOutcome.FAILED)
+    }
+
+    @Test
+    fun `publishes each module directly for snapshot releases`() {
+        p.versionFile.writeText("1.0-SNAPSHOT")
+
+        // Finishes successfully even though we did not provide credentials
+        val result = p.runAndFail("publishAggregationToCentralPortal --offline")
+
+        // Does attempt actual publishing step of 'module-a' (fails only due to --offline)
+        assertThat(p.dir("product/module-a/build/nmcp/m2Maven")).isEmptyDirectory()
+        assertThat(result.output)
+            .contains(
+                "> No cached resource 'https://central.sonatype.com/repository/maven-snapshots/"
+            )
+        assertThat(result.task(":module-a:generateMetadataFileForMavenPublication")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.task(":module-a:generatePomFileForMavenPublication")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.task(":module-a:publishMavenPublicationToNmcpMavenRepository")?.outcome)
+            .isEqualTo(TaskOutcome.FAILED)
+    }
+
+    @Test
+    fun `does not perform auto-release when publishTestRelease=true`() {
+        // Modify some tasks to do nothing, because we cannot actually publish to Maven Central
+        p.aggregationBuildFile(
+            """
+            plugins { id("org.hiero.gradle.feature.publish-maven-central-aggregation") }
+            dependencies { published(project(":module-a")) }
+            tasks.publishAggregationToCentralPortal {
+                actions.clear()
+                doLast { println("publicationType=" + inputs.properties["publicationType"]) }
+            }
+        """
+        )
+        p.moduleBuildFile(
+            """
+            plugins { id("org.hiero.gradle.module.library") }
+            tasks.publishMavenPublicationToSonatypeRepository { actions.clear(); doLast {} }
+            """
+        )
+        val result = p.run("publishAggregationToCentralPortal -PpublishTestRelease=true")
+
+        assertThat(result.task(":module-a:publishMavenPublicationToNmcpMavenRepository")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.task(":module-a:zipMavenPublication")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.task(":aggregation:zipAggregation")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.output).contains("publicationType=USER_MANAGED")
+    }
+
+    @Test
+    fun `can use tasks task without issue if there are no publishing credentials`() {
+        val result = p.run("tasks")
+
+        assertThat(result.task(":tasks")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+}

--- a/src/test/kotlin/org/hiero/gradle/test/fixtures/GradleProject.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/fixtures/GradleProject.kt
@@ -88,6 +88,7 @@ class GradleProject {
     }
 
     fun withEnv(env: Map<String, String>): GradleProject {
+        this.env["PATH"] = System.getenv("PATH") // some plugins use low-level commands like 'uname'
         this.env.putAll(env)
         return this
     }
@@ -121,6 +122,8 @@ class GradleProject {
                 it.writeText(content)
             }
         }
+
+    fun dir(path: String) = File(projectDir, path)
 
     fun help(): BuildResult = runner(listOf("help")).build()
 


### PR DESCRIPTION
**Description**:

The idea is that you then have both mechanisms available (until the old one can be retired for good).

The new mechanism works through the `gradle/aggregation` project, which is more consistent with how we aggregate build results in other cases (e.g. reports). Everything that is going to be published is collected in one `zip` that is then updated.

In the projects, we need to adjust the `gradle/aggregation/build.gradle.kts` as folldows:

```
plugins {
    ...
    id("org.hiero.gradle.feature.publish-maven-central-aggregation") // add new aggregated publish
}

dependencies {
    // all projects that are to be published are part of the new "published" scope
    published(project(":app"))
    published(project(":hedera-protobuf-java-api"))

    // examples.. not published!
    implementation(project(":swirlds-platform-base-example"))
   ...
}

```

And then run:

```
./gradlew publishAggregationToCentralPortal
```

...supporting all the same ENV variables and parameters as the old `releaseMavenCentral`.

**Related issue(s)**:

Fixes #179
