### PR TITLE
221 bug pulling from osssonatypeorg instead of centralsonatypecom

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.feature.repositories.settings.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.repositories.settings.gradle.kts
@@ -19,7 +19,7 @@ dependencyResolutionManagement {
         }
 
         mavenCentral()
-        maven("https://oss.sonatype.org/content/repositories/snapshots")
+        maven(url = "https://central.sonatype.com/repository/maven-snapshots/")
     }
 
     @Suppress("UnstableApiUsage")

--- a/src/main/kotlin/org.hiero.gradle.feature.repositories.settings.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.repositories.settings.gradle.kts
@@ -19,7 +19,7 @@ dependencyResolutionManagement {
         }
 
         mavenCentral()
-        maven(url = "https://central.sonatype.com/repository/maven-snapshots/")
+        maven("https://central.sonatype.com/repository/maven-snapshots")
     }
 
     @Suppress("UnstableApiUsage")


### PR DESCRIPTION
## Description

Updates the snapshots URL to use [Central Publishing Portal Snapshots](https://central.sonatype.com/repository/maven-snapshots) as described by the [Central Publishing Portal Snapshot Documentation](https://central.sonatype.org/publish/publish-portal-snapshots/#consuming-snapshot-releases-for-your-project)

## Related Issue(s)

Fixes #221

