### PR TITLE
build: remove patching for Eclipse Collections

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
@@ -212,8 +212,6 @@ extraJavaModuleInfo {
         exportAllPackages()
         requires("java.logging")
     }
-    module("org.eclipse.collections:eclipse-collections-api", "org.eclipse.collections.api")
-    module("org.eclipse.collections:eclipse-collections", "org.eclipse.collections.impl")
     module("org.xerial.snappy:snappy-java", "org.xerial.snappy.java")
     module("io.prometheus:prometheus-metrics-config", "io.prometheus.metrics.config")
     module("io.prometheus:prometheus-metrics-core", "io.prometheus.metrics.core") {


### PR DESCRIPTION
**Description**:

Reverts: #225 
Required for: https://github.com/hiero-ledger/hiero-consensus-node/pull/19951

This is also needed to make the `JpmsPatchTest` that is currently failing on all branches, as it tests all patched libraries against the latest stable version.