### PR TITLE
Add initial support for more robust git cloning

### DIFF
--- a/src/main/descriptions/org.hiero.gradle.feature.git-clone.txt
+++ b/src/main/descriptions/org.hiero.gradle.feature.git-clone.txt
@@ -1,0 +1,1 @@
+Add support for cloning Git repositories

--- a/src/main/kotlin/org.hiero.gradle.feature.git-clone.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.git-clone.gradle.kts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+import org.hiero.gradle.tasks.GitClone
+
+tasks.register<GitClone>("cloneRemoteRepoWTag") {
+    description = "Clones a remote Git repository"
+
+    group = "hiero"
+
+    url = "https://github.com/hiero-ledger/hiero-solo-action.git"
+    localCloneDirectory = layout.buildDirectory.dir("hiero-solo-action")
+
+    // uncomment below to use a specific tag
+    // tag = "v0.53.0" or a specific commit like "0047255"
+    tag = "efb0134e921b32ed6302da9c93874d65492e876f"
+}

--- a/src/main/kotlin/org/hiero/gradle/tasks/GitClone.kt
+++ b/src/main/kotlin/org/hiero/gradle/tasks/GitClone.kt
@@ -32,6 +32,19 @@ abstract class GitClone : DefaultTask() {
 
     @get:Inject protected abstract val layout: ProjectLayout
 
+    @get:Input @get:Optional abstract val noCheckout: Property<Boolean>
+
+    @get:Input @get:Optional abstract val sparseClone: Property<Boolean>
+
+    @get:Input @get:Optional abstract val cloneDepth: Property<Int>
+
+    @get:Input @get:Optional abstract val filter: Property<String>
+
+    @get:Input @get:Optional abstract val sparseCheckoutPaths: Property<List<String>>
+
+    @get:Input @get:Optional abstract val reset: Property<Boolean>
+
+
     init {
         offline.set(startParameter.isOffline)
         // If a 'branch' is configured, the task is never up-to-date as it may change
@@ -49,31 +62,88 @@ abstract class GitClone : DefaultTask() {
             exec.exec {
                 if (!localClone.dir(".git").asFile.exists()) {
                     workingDir = localClone.asFile.parentFile
-                    commandLine("git", "clone", url.get(), "-q")
+                    // build clone command
+                    val gitCloneStringList: ArrayList<String> = arrayListOf("git", "clone")
+
+                    if (sparseClone.isPresent && sparseClone.get()) {
+                        gitCloneStringList.add("--sparse")
+                    }
+
+                    if (cloneDepth.isPresent) {
+                        gitCloneStringList.add("--depth=${cloneDepth.get()}")
+                    }
+
+                    if (noCheckout.isPresent && noCheckout.get()) {
+                        gitCloneStringList.add("--no-checkout")
+                    }
+
+                    if (filter.isPresent) {
+                        gitCloneStringList.add("--filter=${filter.get()}")
+                    }
+
+                    // add final url and quiet params
+                    gitCloneStringList.add(url.get())
+                    gitCloneStringList.add("-q")
+                    commandLine(gitCloneStringList)
                 } else {
                     workingDir = localClone.asFile
                     commandLine("git", "fetch", "-q")
                 }
             }
         }
-        if (tag.isPresent) {
+
+        // handle sparse checkout
+        if (sparseCheckoutPaths.isPresent) {
             exec.exec {
                 workingDir = localClone.asFile
-                commandLine("git", "checkout", tag.get(), "-q")
+                commandLine("git", "sparse-checkout", "init")
             }
+
+            // build spare-checkout set command
+            val gitSparseCheckoutSetStringList: ArrayList<String> =
+                arrayListOf("git", "sparse-checkout", "set")
+            sparseCheckoutPaths.get().forEach { path -> gitSparseCheckoutSetStringList.add(path) }
+
+            gitSparseCheckoutSetStringList.add("-q")
             exec.exec {
                 workingDir = localClone.asFile
-                commandLine("git", "reset", "--hard", tag.get(), "-q")
-            }
-        } else {
-            exec.exec {
-                workingDir = localClone.asFile
-                commandLine("git", "checkout", branch.get(), "-q")
-            }
-            exec.exec {
-                workingDir = localClone.asFile
-                commandLine("git", "reset", "--hard", "origin/${branch.get()}", "-q")
+                commandLine(gitSparseCheckoutSetStringList)
             }
         }
+
+        if (!reset.isPresent) {
+            // build checkout command
+            val gitCheckoutStringList: ArrayList<String> = arrayListOf("git", "checkout")
+
+            if (tag.isPresent) {
+                gitCheckoutStringList.add(tag.get())
+            } else {
+                gitCheckoutStringList.add("origin/${branch.get()}")
+            }
+
+            gitCheckoutStringList.add("-q")
+            exec.exec {
+                workingDir = localClone.asFile
+                commandLine(gitCheckoutStringList)
+            }
+        }
+        if (reset.isPresent && reset.get()) {
+            // build reset command
+            val gitResetStringList: ArrayList<String> = arrayListOf("git", "reset", "--hard")
+
+            if (tag.isPresent) {
+                gitResetStringList.add(tag.get())
+            } else {
+                gitResetStringList.add("origin/${branch.get()}")
+            }
+
+            gitResetStringList.add("-q")
+            exec.exec {
+                workingDir = localClone.asFile
+                commandLine(gitResetStringList)
+            }
+        }
+
+        println("Successfully cloned or updated $url to ${localClone.asFile.absolutePath}")
     }
 }

--- a/src/test/kotlin/org/hiero/gradle/test/GitCloneTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/GitCloneTest.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.gradle.test
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome
+import org.hiero.gradle.test.fixtures.GradleProject
+import org.junit.jupiter.api.Test
+
+class GitCloneTest {
+    @Test
+    fun `can use GitClone task`() {
+        val push = GradleProject().withMinimalStructure()
+        push.moduleBuildFile("""plugins { id("org.hiero.gradle.feature.git-clone") }""")
+
+        val result = push.run("cloneRemoteRepoWTag")
+
+        assertThat(result.output).contains("Successfully cloned")
+        assertThat(result.task(":cloneRemoteRepoWTag")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+}


### PR DESCRIPTION
**Description**:
The current git clone task pulls in all blobs and details, for a few repos this can result in a heavy download or artifcats as part of a gradle process.

This PR adds additional configs to allow devs to customize the cloning process as needed

**Related issue(s)**:

Fixes #185 

**Notes for reviewer**:
Need to expand and verify tests.
Could also clean up flow as current code is from a quick POC

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
