### PR TITLE
chore: increase Maven Central publishing timeout to 1 hour

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central-aggregation.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central-aggregation.gradle.kts
@@ -28,7 +28,7 @@ nmcpAggregation {
         username = providers.environmentVariable("NEXUS_USERNAME")
         password = providers.environmentVariable("NEXUS_PASSWORD")
         publishingType = if (publishTestRelease) "USER_MANAGED" else "AUTOMATIC"
-        validationTimeout = Duration.of(30, ChronoUnit.MINUTES)
+        validationTimeout = Duration.of(60, ChronoUnit.MINUTES)
     }
 }
 

--- a/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central-aggregation.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central-aggregation.gradle.kts
@@ -28,7 +28,11 @@ nmcpAggregation {
         username = providers.environmentVariable("NEXUS_USERNAME")
         password = providers.environmentVariable("NEXUS_PASSWORD")
         publishingType = if (publishTestRelease) "USER_MANAGED" else "AUTOMATIC"
-        validationTimeout = Duration.of(providers.gradleProperty("mavenCentralTimeout").getOrElse("60").toLong(), ChronoUnit.MINUTES)
+        validationTimeout =
+            Duration.of(
+                providers.gradleProperty("mavenCentralTimeout").getOrElse("60").toLong(),
+                ChronoUnit.MINUTES,
+            )
     }
 }
 

--- a/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central-aggregation.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central-aggregation.gradle.kts
@@ -28,7 +28,7 @@ nmcpAggregation {
         username = providers.environmentVariable("NEXUS_USERNAME")
         password = providers.environmentVariable("NEXUS_PASSWORD")
         publishingType = if (publishTestRelease) "USER_MANAGED" else "AUTOMATIC"
-        Duration.of(providers.gradleProperty("mavenCentralTimeout").getOrElse("60").toLong(), ChronoUnit.MINUTES)
+        validationTimeout = Duration.of(providers.gradleProperty("mavenCentralTimeout").getOrElse("60").toLong(), ChronoUnit.MINUTES)
     }
 }
 

--- a/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central-aggregation.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-maven-central-aggregation.gradle.kts
@@ -28,7 +28,7 @@ nmcpAggregation {
         username = providers.environmentVariable("NEXUS_USERNAME")
         password = providers.environmentVariable("NEXUS_PASSWORD")
         publishingType = if (publishTestRelease) "USER_MANAGED" else "AUTOMATIC"
-        validationTimeout = Duration.of(60, ChronoUnit.MINUTES)
+        Duration.of(providers.gradleProperty("mavenCentralTimeout").getOrElse("60").toLong(), ChronoUnit.MINUTES)
     }
 }
 


### PR DESCRIPTION
**Description**:

Increase the Maven Central publishing timeout to 1 hour.

**Related Issue(s)**:

Fixes #244
Fixes #245 
