### PR TITLE
build: mustRunAfter -> shouldRunAfter in spotless setup

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.check.spotless.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.check.spotless.gradle.kts
@@ -24,7 +24,7 @@ spotless {
 tasks.withType<JavaCompile>().configureEach {
     // When doing a 'qualityGate' run, make sure spotlessApply is done before doing compilation and
     // other checks based on compiled code
-    mustRunAfter(tasks.spotlessApply)
+    shouldRunAfter(tasks.spotlessApply)
 }
 
 tasks.named("qualityCheck") { dependsOn(tasks.spotlessCheck) }


### PR DESCRIPTION
**Description**:

The `mustRunAfter` can cause a cycle with code generation and multiple source sets that have dependencies between each other. The code generation of one project than many need the Jar from another project. For that, the other project needs to be compiled first. But as the spotless formatting is done in one task for **all** source sets, it cannot both run **after** the compilation of all source sets and **before** the code generation of all source sets.

This was discovered working on https://github.com/hashgraph/pbj/pull/595

```
Circular dependency between the following tasks:
ExtraJavaModuleInfoTransform
\--- :jar
     +--- :classes
     |    \--- :compileJava
     |         \--- :spotlessApply
     |              +--- :spotlessJavaApply
     |              |    \--- :spotlessJava
     |              |         \--- :generateCustomPbjSource
     |              \--- :spotlessJavaInfoFilesApply
     |                   \--- :spotlessJavaInfoFiles
     |                        \--- :spotlessJava (*)
     \--- :compileJava (*)
```

This is about the formatting task – `spotlessApply` – that users run individual to format the code. That is, it is not part of the normal (reproducible) build pipeline that runs on CI. When the formatting is correct, the task does nothing. Hence, we can be a bit more lenient here.



**Related issue(s)**:

https://github.com/hashgraph/pbj/pull/595

