### PR TITLE
301 work without git

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.check.spotless.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.check.spotless.gradle.kts
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.hiero.gradle.environment.EnvAccess
+
 plugins {
     id("org.hiero.gradle.base.lifecycle")
     id("com.diffplug.spotless")
@@ -8,17 +10,10 @@ spotless {
     // Disable the automatic application of Spotless to all source sets when the check task is run.
     isEnforceCheck = false
 
-    // limit format enforcement to just the files changed by this feature branch
-    @Suppress("UnstableApiUsage")
-    ratchetFrom(
-        "origin/" +
-            providers
-                .fileContents(
-                    isolated.rootProject.projectDirectory.file("gradle/development-branch.txt")
-                )
-                .asText
-                .getOrElse("main")
-    )
+    if (EnvAccess.isGitRepositoryWithMainBranch(layout.projectDirectory, providers)) {
+        // limit format enforcement to just the files changed by this feature branch
+        ratchetFrom("origin/main")
+    }
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/src/main/kotlin/org.hiero.gradle.feature.git-properties-file.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.git-properties-file.gradle.kts
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.hiero.gradle.environment.EnvAccess
+
 plugins { id("java") }
 
 tasks.register<WriteProperties>("writeGitProperties") {
@@ -29,7 +31,9 @@ tasks.register<WriteProperties>("writeGitProperties") {
     destinationFile = layout.buildDirectory.file("generated/git/git.properties")
 }
 
-tasks.processResources { from(tasks.named("writeGitProperties")) }
+if (EnvAccess.isGitRepositoryWithMainBranch(layout.projectDirectory, providers)) {
+    tasks.processResources { from(tasks.named("writeGitProperties")) }
+}
 
 // ignore the content of 'git.properties' when using a classpath as task input
 normalization.runtimeClasspath { ignore("git.properties") }

--- a/src/main/kotlin/org/hiero/gradle/environment/EnvAccess.kt
+++ b/src/main/kotlin/org/hiero/gradle/environment/EnvAccess.kt
@@ -40,4 +40,15 @@ object EnvAccess {
         providers.environmentVariable("CI").getOrElse("false").let {
             if (it.isBlank()) true else it.toBoolean()
         }
+
+    fun isGitRepositoryWithMainBranch(projectDirectory: Directory, providers: ProviderFactory) =
+        providers
+            .exec {
+                isIgnoreExitValue = true
+                commandLine("git", "rev-parse", "origin/main")
+                workingDir = projectDirectory.asFile
+            }
+            .result
+            .get()
+            .exitValue == 0
 }

--- a/src/test/kotlin/org/hiero/gradle/test/MinimalProjectTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/MinimalProjectTest.kt
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.gradle.test
+
+import java.nio.file.Files
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome
+import org.hiero.gradle.test.fixtures.GradleProject
+import org.junit.jupiter.api.Test
+
+class MinimalProjectTest {
+
+    @Test
+    fun `setup works outside of git repository`() {
+        // run test in a temporary directory to run outside the git repository containing this test
+        val p = GradleProject(Files.createTempDirectory("gt").toFile()).withMinimalStructure()
+        p.moduleBuildFile("""plugins { id("org.hiero.gradle.module.library") }""")
+
+        val result = p.qualityCheck()
+
+        assertThat(result.task(":module-a:compileJava")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+}

--- a/src/test/kotlin/org/hiero/gradle/test/fixtures/GradleProject.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/fixtures/GradleProject.kt
@@ -11,9 +11,9 @@ import org.gradle.testkit.runner.GradleRunner
  * Access to a minimal project inside a temporary folder. The project contain files that are
  * expected to exist in our setup.
  */
-class GradleProject {
-
-    private val projectDir = File("build/test-projects/${UUID.randomUUID()}")
+class GradleProject(
+    private val projectDir: File = File("build/test-projects/${UUID.randomUUID()}")
+) {
 
     val problemsReport = file("build/reports/problems/problems-report.html")
     private val gradlePropertiesFile = file("gradle.properties")


### PR DESCRIPTION
**Description**:

In the two places that right now require `git`, we now do the following:

- Do not use `writeGitProperties` task if the project is not a git repository
- Do not limit which files are checked by spotless in there is no git repository (it just checks all)

This PR also removes the option to define a different name for the `main` branch via `development-branch.txt`, which is no longer required by any _hiero_ project. 

**Related issue(s)**:

Fixes #301

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
