### PR TITLE
build: use Gradle's Problems API to report warnings

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.base.version.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.base.version.gradle.kts
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.hiero.gradle.problems.ProblemReporter
+
 version =
     @Suppress("UnstableApiUsage")
     providers
@@ -9,10 +11,14 @@ version =
                 if (project.parent == null) {
                     ""
                 } else {
-                    val message =
-                        "No version pinned in version.txt file (using: 0.1.0-SNAPSHOT)" +
-                            "\n - Run: ./gradlew versionAsSpecified -PnewVersion=0.1.0"
-                    logger.warn("WARN: $message")
+                    objects
+                        .newInstance<ProblemReporter>()
+                        .warn(
+                            "Version not Pinned",
+                            "No version pinned in version.txt file (using: 0.1.0-SNAPSHOT)",
+                            "version.txt",
+                            "Run: ./gradlew versionAsSpecified -PnewVersion=0.1.0",
+                        )
                     "0.1.0-SNAPSHOT" // fallback value
                 }
             }

--- a/src/main/kotlin/org.hiero.gradle.build.settings.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.build.settings.gradle.kts
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradlex.javamodule.dependencies.initialization.JavaModulesExtension
 import org.gradlex.javamodule.dependencies.initialization.RootPluginsExtension
 import org.hiero.gradle.extensions.PluginVersionsExtensionCreateAction
+import org.hiero.gradle.problems.ProblemReporter
 
 plugins {
     id("org.gradlex.java-module-dependencies")
@@ -13,10 +15,14 @@ plugins {
 val minGradleVersion = "9.1"
 
 if (GradleVersion.current() < GradleVersion.version(minGradleVersion)) {
-    logger.warn(
-        "WARN: The hiero plugins are not fully compatible with the current Gradle version." +
-            "\n - Run: ./gradlew wrapper --gradle-version $minGradleVersion"
-    )
+    serviceOf<ObjectFactory>()
+        .newInstance<ProblemReporter>()
+        .warn(
+            "Wrong Gradle version",
+            "The hiero plugins are not fully compatible with the current Gradle version",
+            "gradle/wrapper/gradle-wrapper.properties",
+            " Run: ./gradlew wrapper --gradle-version $minGradleVersion",
+        )
 }
 
 configure<RootPluginsExtension> {

--- a/src/main/kotlin/org.hiero.gradle.feature.build-cache.settings.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.build-cache.settings.gradle.kts
@@ -1,10 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
+import org.gradle.kotlin.dsl.support.serviceOf
 import org.hiero.gradle.environment.EnvAccess
+import org.hiero.gradle.problems.ProblemReporter
 
 if (!gradle.startParameter.isBuildCacheEnabled) {
-    logger.warn(
-        "WARN: Build cache disabled" + "\n - Add org.gradle.caching=true to gradle.properties"
-    )
+    serviceOf<ObjectFactory>()
+        .newInstance<ProblemReporter>()
+        .warn(
+            "Build Cache Disabled",
+            "",
+            "gradle.properties",
+            "Add org.gradle.caching=true to gradle.properties",
+        )
 }
 
 buildCache {

--- a/src/main/kotlin/org.hiero.gradle.feature.java-compile.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.java-compile.gradle.kts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import org.hiero.gradle.environment.EnvAccess
+import org.hiero.gradle.problems.ProblemReporter
 
 plugins {
     id("java")
@@ -15,10 +16,14 @@ val fullJavaVersion =
         .getting("jdk")
         .orElse(
             provider {
-                val message =
-                    "No 'jdk' version pinned (using: $currentJavaVersion)" +
-                        "\n - Add jdk=$currentJavaVersion to gradle/toolchain-versions.properties"
-                logger.warn("WARN: $message")
+                objects
+                    .newInstance<ProblemReporter>()
+                    .warn(
+                        "Java Version not Pinned",
+                        "No 'jdk' version pinned (using: $currentJavaVersion)",
+                        "gradle/toolchain-versions.properties",
+                        "Add jdk=$currentJavaVersion to gradle/toolchain-versions.properties",
+                    )
                 currentJavaVersion
             }
         )
@@ -26,12 +31,16 @@ val fullJavaVersion =
 val majorJavaVersion = JavaVersion.toVersion(fullJavaVersion)
 
 if (currentJavaVersion != fullJavaVersion) {
-    val message =
-        "Gradle runs with Java $currentJavaVersion. This project works best running with Java $fullJavaVersion. " +
-            "\n - From commandline: change JAVA_HOME and/or PATH to point at Java $fullJavaVersion installation." +
-            "\n - From IntelliJ: change 'Gradle JVM' in 'Gradle Settings' to point at Java $fullJavaVersion installation."
-
-    logger.warn("WARN: $message")
+    objects
+        .newInstance<ProblemReporter>()
+        .warn(
+            "Wrong Java Version",
+            "Gradle runs with Java $currentJavaVersion. This project works best running with Java $fullJavaVersion",
+            "gradle/toolchain-versions.properties",
+            "Point at Java $fullJavaVersion installation: " +
+                "JAVA_HOME and/or PATH (command line), " +
+                "'Gradle JVM' in 'Gradle Settings' (IntelliJ)",
+        )
 }
 
 java {

--- a/src/main/kotlin/org/hiero/gradle/problems/ProblemReporter.kt
+++ b/src/main/kotlin/org/hiero/gradle/problems/ProblemReporter.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.gradle.problems
+
+import javax.inject.Inject
+import org.gradle.api.problems.ProblemGroup
+import org.gradle.api.problems.ProblemId
+import org.gradle.api.problems.Problems
+
+/** Helper to use the Gradle Problems API during build configuration. */
+@Suppress("UnstableApiUsage")
+abstract class ProblemReporter @Inject constructor(val problems: Problems) {
+
+    /**
+     * Add a warning to the 'Problems report' (a link to the report shows at the end of the build).
+     */
+    fun warn(displayName: String, description: String, file: String, solution: String) {
+        val group = ProblemGroup.create("configuration", "Build Configuration")
+        val problemId =
+            ProblemId.create(displayName.lowercase().replace(" ", "-"), displayName, group)
+        problems.reporter.report(problemId) {
+            if (!description.isEmpty()) {
+                this.details(description)
+            }
+            solution(solution)
+            fileLocation(file)
+            documentedAt(
+                "https://github.com/hiero-ledger/hiero-gradle-conventions#project-structure"
+            )
+        }
+    }
+}

--- a/src/test/kotlin/org/hiero/gradle/test/MinimalProjectTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/MinimalProjectTest.kt
@@ -42,6 +42,7 @@ class MinimalProjectTest {
         """
                     .trimIndent()
             )
+            .contains("Problems report is available at:")
     }
 
     @Test
@@ -75,14 +76,6 @@ class MinimalProjectTest {
 
         val result = p.qualityCheck()
 
-        assertThat(result.output)
-            .contains(
-                """
-                WARN: No version pinned in version.txt file (using: 0.1.0-SNAPSHOT)
-                 - Run: ./gradlew versionAsSpecified -PnewVersion=0.1.0
-                WARN: No 'jdk' version pinned (using: 
-        """
-                    .trimIndent()
-            )
+        assertThat(result.output).contains("Problems report is available at:")
     }
 }

--- a/src/test/kotlin/org/hiero/gradle/test/WarningsAndErrorsTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/WarningsAndErrorsTest.kt
@@ -31,16 +31,12 @@ class WarningsAndErrorsTest {
         val p = GradleProject()
         p.settingsFile("plugins { id(\"org.hiero.gradle.build\") }")
 
-        val result = p.runWithOldGradle()
+        p.runWithOldGradle()
 
-        assertThat(result.output)
-            .contains(
-                """
-                WARN: The hiero plugins are not fully compatible with the current Gradle version.
-                 - Run: ./gradlew wrapper --gradle-version 9.1
-        """
-                    .trimIndent()
-            )
+        assertThat(p.problemsReport)
+            .content()
+            .contains("The hiero plugins are not fully compatible with the current Gradle version")
+            .contains("Run: ./gradlew wrapper --gradle-version ")
     }
 
     @Test
@@ -48,16 +44,12 @@ class WarningsAndErrorsTest {
         val p = GradleProject()
         p.settingsFile("plugins { id(\"org.hiero.gradle.build\") }")
 
-        val result = p.noTask()
+        p.noTask()
 
-        assertThat(result.output)
-            .contains(
-                """
-                WARN: Build cache disabled
-                 - Add org.gradle.caching=true to gradle.properties
-        """
-                    .trimIndent()
-            )
+        assertThat(p.problemsReport)
+            .content()
+            .contains("Build Cache Disabled")
+            .contains("Add org.gradle.caching=true to gradle.properties")
     }
 
     @Test
@@ -65,16 +57,12 @@ class WarningsAndErrorsTest {
         val p = GradleProject()
         p.settingsFile("plugins { id(\"org.hiero.gradle.build\") }")
 
-        val result = p.noTask()
+        p.noTask()
 
-        assertThat(result.output)
-            .contains(
-                """
-                WARN: No version pinned in version.txt file (using: 0.1.0-SNAPSHOT)
-                 - Run: ./gradlew versionAsSpecified -PnewVersion=0.1.0
-        """
-                    .trimIndent()
-            )
+        assertThat(p.problemsReport)
+            .content()
+            .contains("No version pinned in version.txt file (using: 0.1.0-SNAPSHOT)")
+            .contains("Run: ./gradlew versionAsSpecified -PnewVersion=0.1.0")
     }
 
     @Test
@@ -107,16 +95,12 @@ class WarningsAndErrorsTest {
         p.moduleBuildFile("""plugins { id("org.hiero.gradle.module.library") }""")
         p.toolchainVersionsFile.delete()
 
-        val result = p.qualityCheck()
+        p.qualityCheck()
 
-        assertThat(result.output)
-            .contains(
-                """
-                WARN: No 'jdk' version pinned (using: 17.0.16)
-                 - Add jdk=17.0.16 to gradle/toolchain-versions.properties
-        """
-                    .trimIndent()
-            )
+        assertThat(p.problemsReport)
+            .content()
+            .contains("No 'jdk' version pinned (using: ")
+            .contains("to gradle/toolchain-versions.properties")
     }
 
     @Test
@@ -133,16 +117,11 @@ class WarningsAndErrorsTest {
                 .trimIndent()
         )
 
-        val result = p.qualityCheck()
+        p.qualityCheck()
 
-        assertThat(result.output)
-            .contains(
-                """
-                WARN: Gradle runs with Java 17.0.16. This project works best running with Java 17.0.99. 
-                 - From commandline: change JAVA_HOME and/or PATH to point at Java 17.0.99 installation.
-                 - From IntelliJ: change 'Gradle JVM' in 'Gradle Settings' to point at Java 17.0.99 installation.
-        """
-                    .trimIndent()
-            )
+        assertThat(p.problemsReport)
+            .content()
+            .contains("This project works best running with Java 17.0.99")
+            .contains("'Gradle JVM' in 'Gradle Settings'")
     }
 }


### PR DESCRIPTION
**Description**:

Follow up to: #317

Instead of printing to the console, we use the new problem reporting API to have WARNINGs show up in the structure HTML report that is linked at the end of the build if any problems are detected.

In the future, we may be able to activate a "fail-on-warning" mode on CI to enforce a stricter handling where desired (https://github.com/gradle/gradle/issues/32994).

**Related issue(s)**:

 #304
 #317
 #7
 #148 
 #260 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
