### PR TITLE
build: add com.gradle:common-custom-user-data-gradle-plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("com.github.node-gradle:gradle-node-plugin:7.1.0") // install NPM for prettier
     implementation("com.google.protobuf:protobuf-gradle-plugin:0.9.5")
     implementation("com.gradle.publish:plugin-publish-plugin:2.0.0")
+    implementation("com.gradle:common-custom-user-data-gradle-plugin:2.4.0")
     implementation("com.gradle:develocity-gradle-plugin:4.2.2")
     implementation("com.gradleup.nmcp:nmcp:1.2.0")
     implementation("com.gradleup.shadow:shadow-gradle-plugin:9.1.0")

--- a/src/main/kotlin/org.hiero.gradle.report.develocity.settings.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.report.develocity.settings.gradle.kts
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import org.hiero.gradle.environment.EnvAccess
 
-plugins { id("com.gradle.develocity") }
+plugins {
+    id("com.gradle.develocity")
+    id("com.gradle.common-custom-user-data-gradle-plugin")
+}
 
 develocity {
     buildScan {


### PR DESCRIPTION
**Description**:
See #329

With this, some useful context information (like git commit hash) are added to each build scan we publish in CI builds.
https://github.com/gradle/common-custom-user-data-gradle-plugin?tab=readme-ov-file#captured-data

**Related issue(s)**:

Resolves #329
