### PR TITLE
fix: micrometer.commons requires java.logging

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
@@ -252,7 +252,11 @@ extraJavaModuleInfo {
         requires("jdk.httpserver")
     }
     module("io.prometheus:simpleclient_tracer_common", "simpleclient.tracer.common")
-    module("io.micrometer:micrometer-commons", "micrometer.commons")
+    module("io.micrometer:micrometer-commons", "micrometer.commons") {
+        exportAllPackages()
+        requireAllDefinedDependencies()
+        requires("java.logging")
+    }
     module("io.micrometer:micrometer-core", "micrometer.core")
     module("io.micrometer:micrometer-observation", "micrometer.observation") {
         exportAllPackages()


### PR DESCRIPTION
**Description**:

See: https://github.com/hashgraph/pbj/pull/673

Fixes the error:
```
JdkLoggerFactory (in module micrometer.commons) cannot access class java.util.logging.Logger (in module java.logging) because module micrometer.commons does not read module java.logging
```