### PR TITLE
ci(runners): Update self-hosted runners to use the new runner config

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -18,7 +18,7 @@ env:
 jobs:
   plugin-portal-release:
     name: Release Gradle Plugin Portal
-    runs-on: hiero-network-node-linux-medium
+    runs-on: hl-gc-gradle-lin
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1

--- a/.github/workflows/flow-deploy-snapshot-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-snapshot-release-artifact.yaml
@@ -21,7 +21,7 @@ env:
 jobs:
   publish-maven-central:
     name: Publish Maven Central
-    runs-on: hiero-network-node-linux-medium
+    runs-on: hl-gc-gradle-lin
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1

--- a/.github/workflows/zxc-build-plugins.yaml
+++ b/.github/workflows/zxc-build-plugins.yaml
@@ -22,7 +22,7 @@ env:
 jobs:
   compile:
     name: Compile and Test
-    runs-on: hiero-network-node-linux-medium
+    runs-on: hl-gc-gradle-lin
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9 # v2.14.1

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 .kotlin
 build
+**/.DS_STORE


### PR DESCRIPTION
## Description

⚠️ This PR will merge during the infrastructure update on 2026-01-29 ⚠️ 

This pull request updates the GitHub Actions workflow configuration to use a new runner type for several jobs. The main change is switching the `runs-on` parameter from `hiero-network-node-linux-medium` to `hl-gc-gradle-lin` in three workflow files.

Workflow runner updates:

* [`.github/workflows/flow-deploy-release-artifact.yaml`](diffhunk://#diff-f1bcd1ef387efde297c1469d5f2c6ed7ba81f38b14e3d54d270914d1125bb2ccL21-R21): Changed the `runs-on` value for the `plugin-portal-release` job to `hl-gc-gradle-lin`.
* [`.github/workflows/flow-deploy-snapshot-release-artifact.yaml`](diffhunk://#diff-7db9cbd40cb7e193fe2b06ef0d451e3df0ea9486c17220b31aea2fb892dbf433L24-R24): Changed the `runs-on` value for the `publish-maven-central` job to `hl-gc-gradle-lin`.
* [`.github/workflows/zxc-build-plugins.yaml`](diffhunk://#diff-e934d748b6b8f06caa72cd3a7d4fd271abc1b32c637b9bfc0530f57ae5b7f208L25-R25): Changed the `runs-on` value for the `compile` job to `hl-gc-gradle-lin`.

## Related Issue(s)

Closes #392 