### PR TITLE
feat: add patch rule for io.prometheus.metrics.exporter.httpserver

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.base.jpms-modules.gradle.kts
@@ -222,6 +222,14 @@ extraJavaModuleInfo {
         // io.prometheus:prometheus-metrics-tracer-initializer is excluded
     }
     module(
+        "io.prometheus:prometheus-metrics-exporter-common",
+        "io.prometheus.metrics.exporter.common",
+    )
+    module(
+        "io.prometheus:prometheus-metrics-exporter-httpserver",
+        "io.prometheus.metrics.exporter.httpserver",
+    )
+    module(
         "io.prometheus:prometheus-metrics-exposition-formats",
         "io.prometheus.metrics.expositionformats",
     )


### PR DESCRIPTION
Required by: https://github.com/hiero-ledger/hiero-consensus-node/blob/main/hiero-observability/openmetrics-httpserver/build.gradle.kts