### PR TITLE
fix: workaround build trying to download metadata for 'protoc:null'

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.feature.protobuf.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.protobuf.gradle.kts
@@ -9,9 +9,9 @@ plugins {
 
 // Configure Protobuf Plugin to download protoc executable rather than using local installed version
 protobuf {
-    protoc { artifact = "com.google.protobuf:protoc:" }
+    protoc { artifact = "com.google.protobuf:protoc:2.5.0" }
     // Add GRPC plugin as we need to generate GRPC services
-    plugins { register("grpc") { artifact = "io.grpc:protoc-gen-grpc-java:" } }
+    plugins { register("grpc") { artifact = "io.grpc:protoc-gen-grpc-java:1.0.0" } }
     generateProtoTasks {
         all().configureEach { plugins.register("grpc") { option("@generated=omit") } }
     }


### PR DESCRIPTION
**Description**:

Always when you start a build with the current version of the plugin, you see it trying to download `com.google.protobuf:protoc:null` for a brief moment.

This is caused by this change in the protobuf plugin:
https://github.com/google/protobuf-gradle-plugin/pull/786/changes

In our case, the `version` is `null` as we want to set it in the projects later. But the string concatenation in the code above turns that into a actual string `"null"`. Gradle then thinks `null` is a legit version and tries to find metadata for it in the Maven Central repository. But as that does not exist, it fails this download and does not cache anything. It does not break the build, because the version is not used, but it will repeatedly try to find the metatdata (assuming it _should_ exist).

I will proose a fix for the protobuf plugin. But it usually takes months until they integrate and release fixes.

Hence, we add this workaround. We set an existing version here. I picked the lowest available on Maven Central. Gradle will then download and cache (!) the metadata for that version. It will still use the higher version, define in the projects. This is only about getting it to cache metadata.