### PR TITLE
fix: increase chances of remote cache hits for 'generateProto'

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.feature.protobuf.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.protobuf.gradle.kts
@@ -15,6 +15,8 @@ protobuf {
     generateProtoTasks {
         all().configureEach { plugins.register("grpc") { option("@generated=omit") } }
     }
+    // https://github.com/google/protobuf-gradle-plugin/issues/785
+    javaExecutablePath = ""
 }
 
 configurations.configureEach {


### PR DESCRIPTION
**Description**:

See: https://github.com/google/protobuf-gradle-plugin/issues/785#issuecomment-4066841635

Should take the quite long running `:hapi:generateProto` task in _hiero-consensus-node_ from the remote cache much more often.