### PR TITLE
feat: add "RunUntilFailure" task for identifying flaky tests

### DIFF
--- a/src/main/descriptions/org.hiero.gradle.feature.run-until-failure.txt
+++ b/src/main/descriptions/org.hiero.gradle.feature.run-until-failure.txt
@@ -1,0 +1,1 @@
+Registers a task that runs a test task repeatedly until it fails, useful for identifying flaky tests

--- a/src/main/kotlin/org.hiero.gradle.feature.run-until-failure.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.run-until-failure.gradle.kts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+import org.hiero.gradle.extensions.RunUntilFailureExtension
+import org.hiero.gradle.tasks.RunUntilFailureTask
+
+val runUntilFailure = extensions.create<RunUntilFailureExtension>("runUntilFailure")
+
+tasks.register<RunUntilFailureTask>("runUntilFailure") {
+    group = "verification"
+    description = "Runs a test task repeatedly until it fails."
+
+    testTaskName.set(runUntilFailure.testTaskName)
+    maxRetries.set(runUntilFailure.maxRetries)
+    testFilters.set(runUntilFailure.testFilters)
+    projectDir.set(rootProject.projectDir)
+    hostProjectPath.set(project.path)
+}

--- a/src/main/kotlin/org.hiero.gradle.feature.test.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.test.gradle.kts
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import org.hiero.gradle.services.TaskLockService
 
-plugins { id("java") }
+plugins {
+    id("java")
+    id("org.hiero.gradle.feature.run-until-failure")
+}
 
 @Suppress("UnstableApiUsage")
 testing.suites {
@@ -43,4 +46,13 @@ if (activeProcessorCount.isPresent) {
         )
         jvmArgs("-XX:ActiveProcessorCount=${activeProcessorCount.get()}")
     }
+}
+
+// Also register the "run until failure" task on the root project (once) so it can be
+// invoked with absolute task paths:
+//   ./gradlew :runUntilFailure --testTaskName :submodule:taskName
+// Subprojects get the task via the plugin applied above, supporting relative paths:
+//   ./gradlew :submodule:runUntilFailure --testTaskName taskName
+if (rootProject.extensions.findByName("runUntilFailure") == null) {
+    rootProject.plugins.apply("org.hiero.gradle.feature.run-until-failure")
 }

--- a/src/main/kotlin/org/hiero/gradle/extensions/RunUntilFailureExtension.kt
+++ b/src/main/kotlin/org/hiero/gradle/extensions/RunUntilFailureExtension.kt
@@ -1,0 +1,40 @@
+package org.hiero.gradle.extensions
+
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+
+abstract class RunUntilFailureExtension {
+    /**
+     * The name of the test task to run repeatedly.
+     * Defaults to "test".
+     */
+    abstract val testTaskName: Property<String>
+
+    /**
+     * Maximum number of times to run the test task.
+     * A value of 0 means run indefinitely until failure.
+     * Defaults to 0 (unlimited).
+     */
+    abstract val maxRetries: Property<Int>
+
+    /**
+     * Optional test filters forwarded to the target task via `--tests`.
+     * Supports the same patterns as Gradle's built-in test filtering:
+     *   - fully-qualified class:      "com.example.MyTest"
+     *   - specific method:            "com.example.MyTest.myMethod"
+     *   - wildcard:                   "com.example.*"
+     *   - simple class name:          "MyTest"
+     *
+     * Example (build.gradle.kts):
+     *   runUntilFailure {
+     *       testFilters.set(listOf("com.example.FlakyTest.flakyMethod"))
+     *   }
+     */
+    abstract val testFilters: ListProperty<String>
+
+    init {
+        testTaskName.convention("test")
+        maxRetries.convention(0)
+        testFilters.convention(emptyList())
+    }
+}

--- a/src/main/kotlin/org/hiero/gradle/tasks/RunUntilFailureTask.kt
+++ b/src/main/kotlin/org/hiero/gradle/tasks/RunUntilFailureTask.kt
@@ -1,0 +1,205 @@
+package org.hiero.gradle.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import org.gradle.tooling.GradleConnector
+import java.io.File
+
+/**
+ * A custom Gradle task that runs a specified test task repeatedly until a failure occurs or 
+ * a maximum number of retries is reached.
+ *
+ * This task provides the ability to configure test task names, apply test filters, and limit 
+ * the number of retries. It can be used to identify flaky tests or repeatedly validate test execution.
+ *
+ * The task launches the target task in a fresh sub-build via the Gradle Tooling API to ensure 
+ * UP-TO-DATE caching never skips execution.
+ *
+ * Properties:
+ * - `testTaskName`: The name of the test task to run until failure.
+ * - `maxRetries`: The maximum number of retries allowed. A value of `0` indicates unlimited retries.
+ * - `testFilters`: A list of test filter patterns forwarded to the test task. These patterns follow 
+ *   the syntax supported by Gradle's built-in test filtering (e.g., class name, method name, 
+ *   wildcard patterns). Optional.
+ *
+ * Task Behavior:
+ * - The task will execute the specified test task in a loop until either a test failure occurs 
+ *   or the configured maximum retry count is reached.
+ * - Each execution uses `--rerun-tasks` to bypass UP-TO-DATE checks and ensure fresh execution.
+ * - If a failure is detected during an execution, the task stops and throws a `GradleException`.
+ * - Test filter patterns can be specified for precisely targeting specific tests during execution.
+ *
+ * Usage Notes:
+ * - Configure the properties either via the `runUntilFailure` extension or as command-line
+ *   options when invoking the task.
+ * - Ensure that the target test task exists and is correctly named in the configuration.
+ * - To test local changes to this plugin in another project, use `--include-build` to
+ *   override the published conventions with your local checkout:
+ *   ```
+ *   ./gradlew :runUntilFailure \
+ *       --include-build /path/to/hiero-gradle-conventions \
+ *       --testTaskName :my-module:test \
+ *       --tests "com.example.FlakyTest" \
+ *       --maxRetries 5
+ *   ```
+ */
+abstract class RunUntilFailureTask : DefaultTask() {
+
+    @get:Input
+    @get:Option(
+        option = "testTaskName",
+        description = "The name of the test task to run until failure."
+    )
+    abstract val testTaskName: Property<String>
+
+    @get:Input
+    @get:Option(option = "maxRetries", description = "Maximum number of retries (0 = unlimited).")
+    abstract val maxRetries: Property<Int>
+
+    /**
+     * One or more test filter patterns forwarded to the target task via `--tests`.
+     * Accepts the same syntax as Gradle's built-in test filtering:
+     *
+     *   --tests "com.example.MyTest"               (whole class)
+     *   --tests "com.example.MyTest.myMethod"       (single method)
+     *   --tests "com.example.*"                     (package wildcard)
+     *   --tests "MyTest"                            (simple class name)
+     *
+     * May be specified multiple times on the command line:
+     *   ./gradlew runUntilFailure \
+     *       --tests "com.example.FlakyTest.methodA" \
+     *       --tests "com.example.FlakyTest.methodB"
+     *
+     * Or set via the extension:
+     *   runUntilFailure {
+     *       testFilters.set(listOf("com.example.FlakyTest.methodA"))
+     *   }
+     */
+    @get:Input
+    @get:Optional
+    @get:Option(
+        option = "tests",
+        description = "Test filter pattern(s) forwarded to the target task (repeatable)."
+    )
+    abstract val testFilters: ListProperty<String>
+
+    @get:Input
+    abstract val projectDir: Property<File>
+
+    /**
+     * The Gradle path of the project hosting this task.
+     * Used to resolve relative [testTaskName] values to absolute task paths in
+     * the Tooling API sub-build.  Empty string means root project.
+     */
+    @get:Input
+    abstract val hostProjectPath: Property<String>
+
+    /**
+     * Executes the configured test task repeatedly until a failure occurs or the maximum retry count is reached.
+     */
+    @TaskAction
+    fun runUntilFailure() {
+        val taskName = resolveTaskName(testTaskName.get())
+        val max = maxRetries.get()
+        val unlimited = max == 0
+        val filters = testFilters.get()
+
+        printHorizontalRule()
+        logger.lifecycle("▶ [RunUntilFailure] targeting task '$taskName'")
+        logger.lifecycle("  Max retries  : ${if (unlimited) "unlimited" else max}")
+        if (filters.isNotEmpty()) {
+            logger.lifecycle("  Test filters : ${filters.joinToString(", ")}")
+        }
+        printHorizontalRule()
+
+        var attempt = 0
+
+        while (true) {
+            attempt++
+            val label = if (unlimited) "attempt $attempt" else "attempt $attempt / $max"
+            logger.lifecycle("")
+            logger.lifecycle("──────────────────────────────────────────────────────────")
+            logger.lifecycle("🔁  Run $label")
+            logger.lifecycle("──────────────────────────────────────────────────────────")
+
+            val result = executeTask(taskName, filters)
+
+            if (result.isFailure) {
+                logger.lifecycle("")
+                printHorizontalRule()
+                logger.lifecycle("❌  FAILURE detected on $label — stopping.")
+                printHorizontalRule()
+                throw GradleException(
+                    "Task '$taskName' failed on $label. " +
+                            "See test reports for details."
+                )
+            }
+
+            logger.lifecycle("✅  $label passed.")
+
+            if (!unlimited && attempt >= max) {
+                logger.lifecycle("")
+                printHorizontalRule()
+                logger.lifecycle("🏁  Reached max retries ($max) without a failure.")
+                printHorizontalRule()
+                break
+            }
+        }
+    }
+
+    /**
+     * Launches the target task in a fresh sub-build via the Gradle Tooling API
+     * so that UP-TO-DATE caching never skips execution.
+     *
+     * [filters] are forwarded as repeated `--tests <pattern>` arguments, which
+     * Gradle's Test task natively understands.
+     */
+    private fun executeTask(taskName: String, filters: List<String>): Result<Unit> {
+        return runCatching {
+            val connection = GradleConnector
+                .newConnector()
+                .forProjectDirectory(projectDir.get())
+                .connect()
+
+            connection.use { conn ->
+                // --rerun-tasks disables UP-TO-DATE checks so the test task
+                // actually executes on every iteration.
+                // Task-specific options like --tests must be passed alongside task
+                // names via withArguments so Gradle's CLI parser can associate
+                // the option with the preceding test task.
+                val args = mutableListOf(taskName, "--rerun-tasks")
+                filters.forEach {
+                    args.add("--tests")
+                    args.add(it)
+                }
+
+                conn.newBuild()
+                    .withArguments(args)
+                    .setStandardOutput(System.out)
+                    .setStandardError(System.err)
+                    .run()
+            }
+        }
+    }
+
+    /**
+     * If [taskName] is already absolute (starts with `:`), return it as-is.
+     * Otherwise prepend [hostProjectPath] so the Tooling API sub-build
+     * resolves it against the correct subproject.
+     */
+    private fun resolveTaskName(taskName: String): String {
+        if (taskName.startsWith(':')) return taskName
+        val host = hostProjectPath.get()
+        return if (host.isEmpty() || host == ":") taskName else "$host:$taskName"
+    }
+
+    private fun printHorizontalRule() {
+        logger.lifecycle("=".repeat(60))
+    }
+}

--- a/src/test/kotlin/org/hiero/gradle/tasks/RunUntilFailureTaskTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/tasks/RunUntilFailureTaskTest.kt
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.gradle.tasks
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Functional tests for [RunUntilFailureTask].
+ *
+ * Each test uses two separate Gradle projects:
+ *  - **outer** (`projectDir/`): applies the `run-until-failure` plugin via TestKit's
+ *    [GradleRunner.withPluginClasspath] and hosts the `runUntilFailure` task.
+ *  - **target** (`projectDir/target/`): a standalone Gradle build that the Tooling
+ *    API sub-build connects to.  It does NOT reference the plugin, so the sub-build
+ *    can configure without needing the plugin on its classpath.
+ *
+ * This two-project layout is necessary because the Tooling API launches a fresh
+ * Gradle process that does not inherit TestKit's injected plugin classpath.  In a
+ * real project the plugin is resolved via `includeBuild` or a plugin repository,
+ * which both processes can access — but that approach is too slow for unit tests
+ * (each sub-build would re-resolve the included build).
+ */
+class RunUntilFailureTaskTest {
+
+    @TempDir
+    @JvmField
+    var projectDir: File? = null
+
+    private lateinit var buildFile: File
+    private lateinit var targetDir: File
+
+    @BeforeEach
+    fun setup() {
+        val dir = projectDir!!
+        buildFile = dir.resolve("build.gradle.kts")
+        targetDir = dir.resolve("target")
+        targetDir.mkdirs()
+    }
+
+    @Test
+    fun `task reaches max retries if no failure`() {
+        writeTargetProject()
+        writeTargetTest("PassingTest", passing = true)
+        writeOuterBuildFile(maxRetries = 2)
+
+        val result = runBuild("runUntilFailure")
+
+        assertThat(result.output).contains("🔁  Run attempt 1 / 2")
+        assertThat(result.output).contains("🔁  Run attempt 2 / 2")
+        assertThat(result.output).contains("🏁  Reached max retries (2) without a failure.")
+        assertThat(result.task(":runUntilFailure")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    @Test
+    fun `task stops on failure`() {
+        writeTargetProject()
+        writeTargetTest("FailingTest", passing = false)
+        writeOuterBuildFile(maxRetries = 5)
+
+        val result = runBuildAndFail("runUntilFailure")
+
+        assertThat(result.output).contains("🔁  Run attempt 1 / 5")
+        assertThat(result.output).contains("❌  FAILURE detected on attempt 1 / 5 — stopping.")
+        assertThat(result.task(":runUntilFailure")?.outcome).isEqualTo(TaskOutcome.FAILED)
+    }
+
+    @Test
+    fun `task respects absolute subproject task path`() {
+        writeTargetMultiProject()
+        writeTargetTest("SubTest", passing = true, subproject = "sub")
+        writeOuterBuildFile(maxRetries = 1, testTaskName = ":sub:test")
+
+        val result = runBuild("runUntilFailure")
+
+        assertThat(result.output).contains("Run attempt 1 / 1")
+        assertThat(result.output).contains(":sub:test")
+        assertThat(result.output).contains("✅  attempt 1 / 1 passed.")
+    }
+
+    @Test
+    fun `subproject task resolves relative task name`() {
+        writeTargetMultiProject()
+        writeTargetTest("SubTest", passing = true, subproject = "sub")
+        // hostProjectPath = ":sub" makes the task resolve "test" → ":sub:test"
+        writeOuterBuildFile(maxRetries = 1, hostProjectPath = ":sub")
+
+        val result = runBuild("runUntilFailure")
+
+        assertThat(result.output).contains("Run attempt 1 / 1")
+        assertThat(result.output).contains(":sub:test")
+        assertThat(result.output).contains("✅  attempt 1 / 1 passed.")
+    }
+
+    @Test
+    fun `task forwards test filters`() {
+        writeTargetProject()
+        writeTargetTest("PassingTest", passing = true)
+        writeOuterBuildFile(maxRetries = 1, filters = listOf("PassingTest.test"))
+
+        val result = runBuild("runUntilFailure")
+
+        assertThat(result.output).contains("Test filters : PassingTest.test")
+        assertThat(result.output).contains("✅  attempt 1 / 1 passed.")
+        assertThat(result.task(":runUntilFailure")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    // -- Target project (Tooling API sub-build) ------------------------------
+
+    /** Single-project target with java-library and JUnit 5. */
+    private fun writeTargetProject() {
+        targetDir.resolve("settings.gradle.kts").writeText(
+            """rootProject.name = "target"""".trimIndent()
+        )
+        targetDir.resolve("build.gradle.kts").writeText(javaTestBuildScript())
+    }
+
+    /** Multi-project target with a `sub` subproject. */
+    private fun writeTargetMultiProject() {
+        targetDir.resolve("settings.gradle.kts").writeText(
+            """
+            rootProject.name = "target"
+            include("sub")
+        """.trimIndent()
+        )
+        targetDir.resolve("build.gradle.kts").writeText("// root project")
+        val subDir = targetDir.resolve("sub")
+        subDir.mkdirs()
+        subDir.resolve("build.gradle.kts").writeText(javaTestBuildScript())
+    }
+
+    private fun writeTargetTest(
+        className: String,
+        passing: Boolean,
+        subproject: String? = null
+    ) {
+        val base = if (subproject != null) targetDir.resolve(subproject) else targetDir
+        val testDir = base.resolve("src/test/java")
+        testDir.mkdirs()
+        val assertion = if (passing) "assertTrue(true);" else "assertTrue(false);"
+        testDir.resolve("$className.java").writeText(
+            """
+            import org.junit.jupiter.api.Test;
+            import static org.junit.jupiter.api.Assertions.assertTrue;
+
+            public class $className {
+                @Test void test() { $assertion }
+            }
+        """.trimIndent()
+        )
+    }
+
+    // -- Outer project (TestKit) ---------------------------------------------
+
+    private fun writeOuterBuildFile(
+        maxRetries: Int = 0,
+        testTaskName: String? = null,
+        hostProjectPath: String? = null,
+        filters: List<String> = emptyList()
+    ) {
+        val taskNameLine = if (testTaskName != null)
+            """testTaskName.set("$testTaskName")""" else ""
+        val hostPathLine = if (hostProjectPath != null)
+            """hostProjectPath.set("$hostProjectPath")""" else ""
+        val filterLine = if (filters.isNotEmpty())
+            """runUntilFailure { testFilters.set(listOf(${filters.joinToString { "\"$it\"" }})) }"""
+        else ""
+
+        buildFile.writeText(
+            """
+            plugins { id("org.hiero.gradle.feature.run-until-failure") }
+
+            runUntilFailure { maxRetries.set($maxRetries) }
+            $filterLine
+
+            tasks.named<org.hiero.gradle.tasks.RunUntilFailureTask>("runUntilFailure") {
+                projectDir.set(file("target"))
+                $taskNameLine
+                $hostPathLine
+            }
+        """.trimIndent()
+        )
+    }
+
+    // -- Helpers --------------------------------------------------------------
+
+    private fun javaTestBuildScript(): String =
+        """
+        plugins { `java-library` }
+        repositories { mavenCentral() }
+        dependencies {
+            testImplementation(platform("org.junit:junit-bom:5.10.2"))
+            testImplementation("org.junit.jupiter:junit-jupiter")
+            testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+        }
+        tasks.named<Test>("test") { useJUnitPlatform() }
+    """.trimIndent()
+
+    private fun runBuild(vararg args: String): BuildResult =
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments(*args)
+            .build()
+
+    private fun runBuildAndFail(vararg args: String): BuildResult =
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments(*args)
+            .buildAndFail()
+}


### PR DESCRIPTION
### Description:

In the execution team, we've been investing some time to reduce the amount of flaky tests. During this effort, I noticed that everyone had their own bash script (or any other solution) to repeatedly run tests until they fail, proving it a flaky test. Then, I wondered that would be good to have it built in Gradle, so everyone could benefit from it.
                                                                                                                                                                                                                                                                                                                    
This PR adds `runUntilFailure` task for identifying flaky tests by repeatedly running a test task until it fails or a maximum retry count is reached.
                                                                                                                                                                                                                                                                                                                    
  * Add `RunUntilFailureTask` that launches sub-builds via the Gradle Tooling API to bypass UP-TO-DATE caching;                                                                                                                                                                                                       
  * Add `RunUntilFailureExtension` for DSL configuration of testTaskName, maxRetries, and testFilters;                                                                                                                                                                                                                
  * Add `org.hiero.gradle.feature.run-until-failure` convention plugin to register the task on any project;                                                                                                                                                                                                           
  * Apply the new plugin in org.hiero.gradle.feature.test for every subproject and once on root;                                                                                                                                                                                                                    
  * Support both absolute (`--testTaskName :test-clients:testRepeatable`) and relative (`--testTaskName testRepeatable`) task paths;                                                                                                                                                                                    
  * Forward `--tests` filter patterns to the sub-build via withArguments (Tooling API does not support task-specific options via addArguments);                                                                                                                                                                       
  * Derive clean<TaskName> dynamically from the target task name instead of hardcoding cleanTest;                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                    
  ### Related issue(s):                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                    
N/A                                                                                                                                                                                                                                                                                                
                                                            
  ### Notes for reviewer:

  Invocation examples:

  From root with absolute path
```
  ./gradlew :runUntilFailure --testTaskName :test-clients:testRepeatable --tests "com.example.FlakyTest" --maxRetries 5                                                                                                                                                                                             
```
                                                                                                                                                                                                                                                                                                                    
From subproject with relative path                                                                                                                                                                                                                                                                            
``` 
  ./gradlew :test-clients:runUntilFailure --testTaskName testRepeatable --tests "com.example.FlakyTest" --maxRetries 5                                                                                                                                                                                              
```                                                                                                                                                                                                                                                                                                                    

### Checklist:
                                                                                                                                                                                                                                                                                                                    
  - [x] Documented (Code comments, README, etc.)            
  - [x] Tested (unit, integration, etc.)
                                                               