### PR TITLE
chore: add ability to publish to different orgs

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.feature.publish-maven-repository.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-maven-repository.gradle.kts
@@ -51,23 +51,29 @@ publishing.publications.withType<MavenPublication>().configureEach {
         }
 
         @Suppress("UnstableApiUsage") val repoName = isolated.rootProject.name
+        val gitHubOrg =
+            providers
+                .environmentVariable("GITHUB_REPOSITORY")
+                .map { it.substringBefore("/") }
+                .orElse(providers.gradleProperty("publishGitHubOrg"))
+                .orElse("hiero-ledger")
 
         issueManagement {
             system = "GitHub"
-            url = "https://github.com/hiero-ledger/$repoName/issues"
+            url = "https://github.com/${gitHubOrg.get()}/$repoName/issues"
         }
 
         licenses {
             license {
                 name = "Apache License, Version 2.0"
-                url = "https://raw.githubusercontent.com/hiero-ledger/$repoName/main/LICENSE"
+                url = "https://raw.githubusercontent.com/${gitHubOrg.get()}/$repoName/main/LICENSE"
             }
         }
 
         scm {
-            connection = "scm:git:git://github.com/hiero-ledger/$repoName.git"
-            developerConnection = "scm:git:ssh://github.com:hiero-ledger/$repoName.git"
-            url = "https://github.com/hiero-ledger/$repoName"
+            connection = "scm:git:git://github.com/${gitHubOrg.get()}/$repoName.git"
+            developerConnection = "scm:git:ssh://github.com:${gitHubOrg.get()}/$repoName.git"
+            url = "https://github.com/${gitHubOrg.get()}/$repoName"
         }
 
         developers {

--- a/src/main/kotlin/org.hiero.gradle.feature.publish-maven-repository.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-maven-repository.gradle.kts
@@ -52,11 +52,7 @@ publishing.publications.withType<MavenPublication>().configureEach {
 
         @Suppress("UnstableApiUsage") val repoName = isolated.rootProject.name
         val gitHubOrg =
-            providers
-                .environmentVariable("GITHUB_REPOSITORY")
-                .map { it.substringBefore("/") }
-                .orElse(providers.gradleProperty("publishGitHubOrg"))
-                .orElse("hiero-ledger")
+            providers.environmentVariable("GITHUB_REPOSITORY_OWNER").getOrElse("hiero-ledger")
 
         issueManagement {
             system = "GitHub"

--- a/src/main/kotlin/org.hiero.gradle.feature.publish-maven-repository.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.publish-maven-repository.gradle.kts
@@ -56,20 +56,20 @@ publishing.publications.withType<MavenPublication>().configureEach {
 
         issueManagement {
             system = "GitHub"
-            url = "https://github.com/${gitHubOrg.get()}/$repoName/issues"
+            url = "https://github.com/$gitHubOrg/$repoName/issues"
         }
 
         licenses {
             license {
                 name = "Apache License, Version 2.0"
-                url = "https://raw.githubusercontent.com/${gitHubOrg.get()}/$repoName/main/LICENSE"
+                url = "https://raw.githubusercontent.com/$gitHubOrg/$repoName/main/LICENSE"
             }
         }
 
         scm {
-            connection = "scm:git:git://github.com/${gitHubOrg.get()}/$repoName.git"
-            developerConnection = "scm:git:ssh://github.com:${gitHubOrg.get()}/$repoName.git"
-            url = "https://github.com/${gitHubOrg.get()}/$repoName"
+            connection = "scm:git:git://github.com/$gitHubOrg/$repoName.git"
+            developerConnection = "scm:git:ssh://github.com:$gitHubOrg/$repoName.git"
+            url = "https://github.com/$gitHubOrg/$repoName"
         }
 
         developers {


### PR DESCRIPTION
**Description**:
This pull request updates the Maven publishing configuration to support customizable GitHub organizations, making the repository metadata more flexible and accurate for forks or alternative organizations. Instead of hardcoding the organization as `hiero-ledger`, it now dynamically determines the organization from environment variables or project properties.

Repository metadata improvements:

* The GitHub organization in all generated Maven POM metadata fields (`issueManagement`, `licenses`, and `scm`) is now dynamically set based on the `GITHUB_REPOSITORY` environment variable, the `publishGitHubOrg` Gradle property, or defaults to `hiero-ledger`. This ensures links and SCM information are correct for forks or other organizations.

**Related issue(s)**:

Fixes #469 
