### PR TITLE
fix: protobuf plugin config

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.feature.protobuf.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.protobuf.gradle.kts
@@ -9,8 +9,9 @@ plugins {
 
 // Configure Protobuf Plugin to download protoc executable rather than using local installed version
 protobuf {
+    // The artifacts below contain unused versions due to
+    // https://github.com/google/protobuf-gradle-plugin/pull/799
     protoc { artifact = "com.google.protobuf:protoc:2.5.0" }
-    // Add GRPC plugin as we need to generate GRPC services
     plugins { register("grpc") { artifact = "io.grpc:protoc-gen-grpc-java:1.0.0" } }
     generateProtoTasks {
         all().configureEach { plugins.register("grpc") { option("@generated=omit") } }
@@ -32,7 +33,16 @@ configurations.configureEach {
         if (name.startsWith("protobufToolsLocator")) {
             // Track all tools as input to react to version changes for the tools
             val protobufToolsLocator = this
-            tasks.withType<GenerateProtoTask>().configureEach { inputs.files(protobufToolsLocator) }
+            tasks.withType<GenerateProtoTask>().configureEach {
+                inputs.property(
+                    protobufToolsLocator.name,
+                    provider {
+                        protobufToolsLocator.incoming.resolutionResult.allComponents.map {
+                            it.moduleVersion
+                        }
+                    },
+                )
+            }
         }
     }
 }

--- a/src/main/kotlin/org.hiero.gradle.feature.protobuf.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.protobuf.gradle.kts
@@ -54,3 +54,12 @@ tasks.javadoc {
         addStringOption("Xdoclint:-reference,-html", "-quiet")
     }
 }
+
+plugins.withId("com.hedera.pbj.pbj-compiler") {
+    // Allow duplicated use of the same 'proto' files as sources for both plugins
+    // See also: https://github.com/google/protobuf-gradle-plugin/issues/812
+    tasks
+        .withType<Jar>()
+        .named { it == "sourcesJar" }
+        .configureEach { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
+}

--- a/src/main/kotlin/org.hiero.gradle.feature.protobuf.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.feature.protobuf.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 // Configure Protobuf Plugin to download protoc executable rather than using local installed version
 protobuf {
     // The artifacts below contain unused versions due to
-    // https://github.com/google/protobuf-gradle-plugin/pull/799
+    // https://github.com/google/protobuf-gradle-plugin/issues/798
     protoc { artifact = "com.google.protobuf:protoc:2.5.0" }
     plugins { register("grpc") { artifact = "io.grpc:protoc-gen-grpc-java:1.0.0" } }
     generateProtoTasks {
@@ -56,7 +56,7 @@ tasks.javadoc {
 }
 
 plugins.withId("com.hedera.pbj.pbj-compiler") {
-    // Allow duplicated use of the same 'proto' files as sources for both plugins
+    // Allow using the same 'proto' files twice as sources for both plugins
     // See also: https://github.com/google/protobuf-gradle-plugin/issues/812
     tasks
         .withType<Jar>()

--- a/src/test/kotlin/org/hiero/gradle/test/ProtobufTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/ProtobufTest.kt
@@ -4,12 +4,16 @@ package org.hiero.gradle.test
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
 import org.hiero.gradle.test.fixtures.GradleProject
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class ProtobufTest {
 
-    @Test
-    fun `task re-runs if protobuf plugin version changes`() {
+    val push = GradleProject().withMinimalStructure()
+    val pull = GradleProject().withMinimalStructure()
+
+    @BeforeEach
+    fun setup() {
         val testProto =
             """
             syntax = "proto3";
@@ -17,14 +21,14 @@ class ProtobufTest {
             message Test {
               bytes test_id = 1;
             }
-        """
+            """
                 .trimIndent()
         val moduleInfo =
             """
             module org.hiero.product.module.a {
                 requires com.google.protobuf;
             }
-        """
+            """
                 .trimIndent()
         val aggregation =
             """
@@ -36,8 +40,6 @@ class ProtobufTest {
             """
                 .trimIndent()
 
-        val push = GradleProject().withMinimalStructure()
-        val pull = GradleProject().withMinimalStructure()
         push.aggregationBuildFile(aggregation)
         pull.aggregationBuildFile(aggregation)
         push.settingsFile.appendText(
@@ -54,7 +56,10 @@ class ProtobufTest {
 
         push.file("product/module-a/src/main/proto/test.proto", testProto)
         pull.file("product/module-a/src/main/proto/test.proto", testProto)
+    }
 
+    @Test
+    fun `task re-runs if protobuf plugin version changes`() {
         push.dependencyVersionsFile(dependencyVersions("4.29.0"))
         pull.dependencyVersionsFile(dependencyVersions("4.29.3"))
 
@@ -68,6 +73,46 @@ class ProtobufTest {
         assertThat(pullResult.task(":module-a:generateProto")?.outcome)
             .isEqualTo(TaskOutcome.SUCCESS)
         assertThat(pullResult.task(":module-a:compileJava")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    @Test
+    fun `task does not re-run if operating system changes`() {
+        // version does not change
+        push.dependencyVersionsFile(dependencyVersions("4.29.3"))
+        pull.dependencyVersionsFile(dependencyVersions("4.29.3"))
+
+        val pushResult = push.run("assemble --build-cache")
+        // simulate different OS
+        val pullResult = pull.run("assemble --build-cache -Dos.arch=x86 -Dos.name=Windows")
+
+        // make sure second run is FROM-CACHE
+        assertThat(pushResult.task(":module-a:generateProto")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(pushResult.task(":module-a:compileJava")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(pullResult.task(":module-a:generateProto")?.outcome)
+            .isEqualTo(TaskOutcome.FROM_CACHE)
+        assertThat(pullResult.task(":module-a:compileJava")?.outcome)
+            .isEqualTo(TaskOutcome.FROM_CACHE)
+    }
+
+    @Test
+    fun `sourcesJar does not fail in protobuf project`() {
+        // version does not change
+        push.dependencyVersionsFile(dependencyVersions("4.29.3"))
+        pull.dependencyVersionsFile(dependencyVersions("4.29.3"))
+
+        val pushResult = push.run("assemble --build-cache")
+        // simulate different OS
+        val pullResult = pull.run("assemble --build-cache -Dos.arch=x86 -Dos.name=Windows")
+
+        // make sure second run is FROM-CACHE
+        assertThat(pushResult.task(":module-a:generateProto")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(pushResult.task(":module-a:compileJava")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(pullResult.task(":module-a:generateProto")?.outcome)
+            .isEqualTo(TaskOutcome.FROM_CACHE)
+        assertThat(pullResult.task(":module-a:compileJava")?.outcome)
+            .isEqualTo(TaskOutcome.FROM_CACHE)
     }
 
     private fun dependencyVersions(protocVersion: String) =

--- a/src/test/kotlin/org/hiero/gradle/test/ProtobufTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/ProtobufTest.kt
@@ -18,6 +18,7 @@ class ProtobufTest {
             """
             syntax = "proto3";
             package org.hiero.product.module.a;
+            option java_package = "org.hiero.product.module.a.proto";
             message Test {
               bytes test_id = 1;
             }
@@ -96,23 +97,23 @@ class ProtobufTest {
     }
 
     @Test
-    fun `sourcesJar does not fail in protobuf project`() {
-        // version does not change
+    fun `sourcesJar does not fail in proejct that combines protobuf and pbj`() {
+        // https://github.com/google/protobuf-gradle-plugin/issues/812
+        push.moduleBuildFile(
+            """
+            plugins {
+                id("org.hiero.gradle.feature.protobuf")
+                id("com.hedera.pbj.pbj-compiler") version "0.9.0"
+            }
+            java.withSourcesJar()
+            """
+                .trimIndent()
+        )
         push.dependencyVersionsFile(dependencyVersions("4.29.3"))
-        pull.dependencyVersionsFile(dependencyVersions("4.29.3"))
 
-        val pushResult = push.run("assemble --build-cache")
-        // simulate different OS
-        val pullResult = pull.run("assemble --build-cache -Dos.arch=x86 -Dos.name=Windows")
+        val pushResult = push.run("sourcesJar")
 
-        // make sure second run is FROM-CACHE
-        assertThat(pushResult.task(":module-a:generateProto")?.outcome)
-            .isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(pushResult.task(":module-a:compileJava")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        assertThat(pullResult.task(":module-a:generateProto")?.outcome)
-            .isEqualTo(TaskOutcome.FROM_CACHE)
-        assertThat(pullResult.task(":module-a:compileJava")?.outcome)
-            .isEqualTo(TaskOutcome.FROM_CACHE)
+        assertThat(pushResult.task(":module-a:sourcesJar")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
     }
 
     private fun dependencyVersions(protocVersion: String) =

--- a/src/test/kotlin/org/hiero/gradle/test/fixtures/GradleProject.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/fixtures/GradleProject.kt
@@ -32,6 +32,7 @@ class GradleProject(
     private val expectedHeader = "// SPDX-License-Identifier: Apache-2.0\n"
 
     private val env = mutableMapOf<String, String>()
+    private val systemProperties = mutableMapOf<String, String>()
 
     fun withMinimalStructure(): GradleProject {
         gradlePropertiesFile.writeText(
@@ -82,6 +83,11 @@ class GradleProject(
     fun withEnv(env: Map<String, String>): GradleProject {
         this.env["PATH"] = System.getenv("PATH") // some plugins use low-level commands like 'uname'
         this.env.putAll(env)
+        return this
+    }
+
+    fun withSystemProperties(systemProperties: Map<String, String>): GradleProject {
+        this.systemProperties.putAll(systemProperties)
         return this
     }
 

--- a/src/test/kotlin/org/hiero/gradle/test/fixtures/GradleProject.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/fixtures/GradleProject.kt
@@ -32,7 +32,6 @@ class GradleProject(
     private val expectedHeader = "// SPDX-License-Identifier: Apache-2.0\n"
 
     private val env = mutableMapOf<String, String>()
-    private val systemProperties = mutableMapOf<String, String>()
 
     fun withMinimalStructure(): GradleProject {
         gradlePropertiesFile.writeText(
@@ -83,11 +82,6 @@ class GradleProject(
     fun withEnv(env: Map<String, String>): GradleProject {
         this.env["PATH"] = System.getenv("PATH") // some plugins use low-level commands like 'uname'
         this.env.putAll(env)
-        return this
-    }
-
-    fun withSystemProperties(systemProperties: Map<String, String>): GradleProject {
-        this.systemProperties.putAll(systemProperties)
         return this
     }
 


### PR DESCRIPTION
**Description**:

Fixes two issues:
- `generateProto` cache results were not used across operation systems. E.g. on my local Mac it did not pull from remote, which has the results from Linux.
- With the latest upgrade to `0.10.0`, there is a clash with PBJ as proto files are not registered as sources twice with Gradle (see https://github.com/google/protobuf-gradle-plugin/issues/812#issuecomment-4404175211)
