### PR TITLE
feat(spotless): add step for sorting moduleInfo blocks in build.gradle.kts files

### DIFF
--- a/src/main/kotlin/org.hiero.gradle.check.spotless-kotlin.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.check.spotless-kotlin.gradle.kts
@@ -7,12 +7,7 @@ plugins { id("com.diffplug.spotless") }
 spotless {
     kotlinGradle {
         ktfmt().kotlinlangStyle()
+        addStep(SortModuleInfoBlocksStep.create())
         licenseHeader(LicenseHeader.HEADER_STYLE_C, LicenseHeader.FIRST_LINE_REGEX_STYLE_C)
     }
-    format("gradleKtsBuildFiles") {
-        target("build.gradle.kts")
-        addStep(SortModuleInfoBlocksStep.create())
-    }
 }
-
-tasks.named("spotlessGradleKtsBuildFiles") { dependsOn(tasks.named("spotlessKotlinGradle")) }

--- a/src/main/kotlin/org.hiero.gradle.check.spotless-kotlin.gradle.kts
+++ b/src/main/kotlin/org.hiero.gradle.check.spotless-kotlin.gradle.kts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import org.hiero.gradle.spotless.LicenseHeader
+import org.hiero.gradle.spotless.SortModuleInfoBlocksStep
 
 plugins { id("com.diffplug.spotless") }
 
@@ -8,4 +9,10 @@ spotless {
         ktfmt().kotlinlangStyle()
         licenseHeader(LicenseHeader.HEADER_STYLE_C, LicenseHeader.FIRST_LINE_REGEX_STYLE_C)
     }
+    format("gradleKtsBuildFiles") {
+        target("build.gradle.kts")
+        addStep(SortModuleInfoBlocksStep.create())
+    }
 }
+
+tasks.named("spotlessGradleKtsBuildFiles") { dependsOn(tasks.named("spotlessKotlinGradle")) }

--- a/src/main/kotlin/org/hiero/gradle/spotless/SortModuleInfoBlocksStep.kt
+++ b/src/main/kotlin/org/hiero/gradle/spotless/SortModuleInfoBlocksStep.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.gradle.spotless
+
+import com.diffplug.spotless.FormatterFunc
+import com.diffplug.spotless.FormatterStep
+
+class SortModuleInfoBlocksStep {
+    companion object {
+        private const val NAME = "SortModuleInfoBlocks"
+
+        fun create(): FormatterStep = FormatterStep.create(NAME, State(), State::toFormatter)
+    }
+
+    private class State : java.io.Serializable {
+
+        fun toFormatter(): FormatterFunc = FormatterFunc { unixStr ->
+            val lines = unixStr.split('\n')
+            val result = mutableListOf<String>()
+            var i = 0
+
+            while (i < lines.size) {
+                val line = lines[i]
+                if (isMultiLineModuleInfoBlockStart(line)) {
+                    result.add(line)
+                    i++
+                    val blockLines = mutableListOf<String>()
+                    while (i < lines.size && !lines[i].trim().startsWith("}")) {
+                        if (lines[i].isNotBlank()) {
+                            blockLines.add(lines[i])
+                        }
+                        i++
+                    }
+                    blockLines.sortBy { it.trim() }
+                    result.addAll(blockLines)
+                    if (i < lines.size) {
+                        result.add(lines[i])
+                    }
+                } else {
+                    result.add(line)
+                }
+                i++
+            }
+
+            result.joinToString("\n")
+        }
+
+        private fun isMultiLineModuleInfoBlockStart(line: String) =
+            Regex("""^\s*\w+ModuleInfo\s*\{""").containsMatchIn(line) && !line.contains('}')
+    }
+}

--- a/src/main/kotlin/org/hiero/gradle/spotless/SortModuleInfoBlocksStep.kt
+++ b/src/main/kotlin/org/hiero/gradle/spotless/SortModuleInfoBlocksStep.kt
@@ -7,6 +7,7 @@ import com.diffplug.spotless.FormatterStep
 class SortModuleInfoBlocksStep {
     companion object {
         private const val NAME = "SortModuleInfoBlocks"
+        private val OWN_PACKAGES = listOf("com.swirlds.", "com.hedera", "org.hiero")
 
         fun create(): FormatterStep = FormatterStep.create(NAME, State(), State::toFormatter)
     }
@@ -18,22 +19,70 @@ class SortModuleInfoBlocksStep {
             val result = mutableListOf<String>()
             var i = 0
 
+            val ownPackagesComparator =
+                Comparator<String> { a, b ->
+                    val nameA = a.trim().substringAfter("(\"").substringBefore("\")")
+                    val nameB = b.trim().substringAfter("(\"").substringBefore("\")")
+                    if (
+                        OWN_PACKAGES.any { nameA.startsWith(it) } &&
+                            OWN_PACKAGES.none { nameB.startsWith(it) }
+                    ) {
+                        -1
+                    } else if (
+                        OWN_PACKAGES.none { nameA.startsWith(it) } &&
+                            OWN_PACKAGES.any { nameB.startsWith(it) }
+                    ) {
+                        1
+                    } else {
+                        nameA.compareTo(nameB)
+                    }
+                }
+
             while (i < lines.size) {
                 val line = lines[i]
-                if (isMultiLineModuleInfoBlockStart(line)) {
+                if (line.isMultiLineModuleInfoBlockStart()) {
                     result.add(line)
                     i++
-                    val blockLines = mutableListOf<String>()
+
+                    val annotationProcessors = mutableListOf<String>()
+                    val requires = mutableListOf<String>()
+                    val requiresStatic = mutableListOf<String>()
+                    val runtimeOnly = mutableListOf<String>()
+                    val others = mutableListOf<String>()
+
                     while (i < lines.size && !lines[i].trim().startsWith("}")) {
-                        if (lines[i].isNotBlank()) {
-                            blockLines.add(lines[i])
+                        val entry = lines[i]
+                        if (entry.isNotBlank()) {
+                            val trimmed = entry.trim()
+                            when {
+                                trimmed.startsWith("annotationProcessor(") ->
+                                    annotationProcessors.add(entry)
+                                trimmed.startsWith("requiresStatic(") -> requiresStatic.add(entry)
+                                trimmed.startsWith("requires(") -> requires.add(entry)
+                                trimmed.startsWith("runtimeOnly(") -> runtimeOnly.add(entry)
+                                else -> others.add(entry) // exportsTo, opensTo
+                            }
                         }
                         i++
                     }
-                    blockLines.sortBy { it.trim() }
-                    result.addAll(blockLines)
+
+                    annotationProcessors.sortWith(ownPackagesComparator)
+                    requires.sortWith(ownPackagesComparator)
+                    requiresStatic.sortWith(ownPackagesComparator)
+                    runtimeOnly.sortWith(ownPackagesComparator)
+                    others.sortBy { it.trim() }
+
+                    val groups =
+                        listOf(annotationProcessors, requires + requiresStatic, runtimeOnly, others)
+                            .filter { it.isNotEmpty() }
+
+                    groups.forEachIndexed { idx, group ->
+                        if (idx > 0) result.add("")
+                        result.addAll(group)
+                    }
+
                     if (i < lines.size) {
-                        result.add(lines[i])
+                        result.add(lines[i]) // closing brace
                     }
                 } else {
                     result.add(line)
@@ -44,7 +93,7 @@ class SortModuleInfoBlocksStep {
             result.joinToString("\n")
         }
 
-        private fun isMultiLineModuleInfoBlockStart(line: String) =
-            Regex("""^\s*\w+ModuleInfo\s*\{""").containsMatchIn(line) && !line.contains('}')
+        private fun String.isMultiLineModuleInfoBlockStart() =
+            Regex("""^\s*\w+ModuleInfo\s*\{""").containsMatchIn(this) && !this.contains('}')
     }
 }

--- a/src/test/kotlin/org/hiero/gradle/test/QualityGateTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/QualityGateTest.kt
@@ -242,6 +242,40 @@ class QualityGateTest {
     }
 
     @Test
+    fun `spotlessApply sorts entries in moduleInfo blocks in build gradle kts files`() {
+        val p = GradleProject().withMinimalStructure()
+        val buildFile =
+            p.moduleBuildFile(
+                """
+                plugins { id("org.hiero.gradle.module.library") }
+
+                testModuleInfo {
+                    requires("org.junit.jupiter.params")
+                    requires("org.junit.jupiter.api")
+                }
+                """
+                    .trimIndent()
+            )
+
+        val result = p.run("spotlessApply")
+
+        assertThat(buildFile)
+            .hasContent(
+                """
+                // SPDX-License-Identifier: Apache-2.0
+                plugins { id("org.hiero.gradle.module.library") }
+
+                testModuleInfo {
+                    requires("org.junit.jupiter.api")
+                    requires("org.junit.jupiter.params")
+                }
+                """
+                    .trimIndent()
+            )
+        assertThat(result.task(":spotlessApply")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    @Test
     fun `spotlessApply formats rust files`() {
         val p = GradleProject().withMinimalStructure()
         p.moduleBuildFile(

--- a/src/test/kotlin/org/hiero/gradle/test/QualityGateTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/QualityGateTest.kt
@@ -251,7 +251,9 @@ class QualityGateTest {
 
                 testModuleInfo {
                     requires("org.junit.jupiter.params")
+                    requiresStatic("org.hiero.gradle.check.spotless")
                     requires("org.junit.jupiter.api")
+                    requires("org.hiero.consensus.node.app")
                 }
                 """
                     .trimIndent()
@@ -266,8 +268,10 @@ class QualityGateTest {
                 plugins { id("org.hiero.gradle.module.library") }
 
                 testModuleInfo {
+                    requires("org.hiero.consensus.node.app")
                     requires("org.junit.jupiter.api")
                     requires("org.junit.jupiter.params")
+                    requiresStatic("org.hiero.gradle.check.spotless")
                 }
                 """
                     .trimIndent()


### PR DESCRIPTION
**Description**:
Adds `SortModuleInfoBlocksStep`, a Spotless `FormatterStep` that sorts the entries inside *ModuleInfo { } blocks (e.g. `mainModuleInfo`, `testModuleInfo`) alphabetically in `build.gradle.kts` files. The step is registered as a separate Spotless format extension targeting `build.gradle.kts`, running after `spotlessKotlinGradle (ktfmt)`.

**Related issue(s)**:
Fixes #503 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
