### PR TITLE
feat: fail if there are warnings in --warning-mode=fail

### DIFF
--- a/src/main/kotlin/org/hiero/gradle/problems/ProblemReporter.kt
+++ b/src/main/kotlin/org/hiero/gradle/problems/ProblemReporter.kt
@@ -2,30 +2,43 @@
 package org.hiero.gradle.problems
 
 import javax.inject.Inject
+import org.gradle.StartParameter
+import org.gradle.api.logging.configuration.WarningMode
 import org.gradle.api.problems.ProblemGroup
 import org.gradle.api.problems.ProblemId
 import org.gradle.api.problems.Problems
 
 /** Helper to use the Gradle Problems API during build configuration. */
 @Suppress("UnstableApiUsage")
-abstract class ProblemReporter @Inject constructor(val problems: Problems) {
+abstract class ProblemReporter
+@Inject
+constructor(val problems: Problems, val startParameters: StartParameter) {
 
     /**
      * Add a warning to the 'Problems report' (a link to the report shows at the end of the build).
      */
     fun warn(displayName: String, description: String, file: String, solution: String) {
+        val fail = startParameters.warningMode == WarningMode.Fail
         val group = ProblemGroup.create("configuration", "Build Configuration")
         val problemId =
             ProblemId.create(displayName.lowercase().replace(" ", "-"), displayName, group)
-        problems.reporter.report(problemId) {
-            if (!description.isEmpty()) {
-                this.details(description)
+
+        val problem =
+            problems.reporter.create(problemId) {
+                if (!description.isEmpty()) {
+                    details(description)
+                }
+                solution(solution)
+                fileLocation(file)
+                documentedAt(
+                    "https://github.com/hiero-ledger/hiero-gradle-conventions#project-structure"
+                )
             }
-            solution(solution)
-            fileLocation(file)
-            documentedAt(
-                "https://github.com/hiero-ledger/hiero-gradle-conventions#project-structure"
-            )
+
+        if (fail) {
+            problems.reporter.throwing(IllegalStateException(displayName), problem)
+        } else {
+            problems.reporter.report(problem)
         }
     }
 }

--- a/src/test/kotlin/org/hiero/gradle/test/WarningsAndErrorsTest.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/WarningsAndErrorsTest.kt
@@ -16,8 +16,8 @@ class WarningsAndErrorsTest {
             # SPDX-License-Identifier: Apache-2.0
             org.gradle.configuration-cache=true
             org.gradle.caching=true
-            
-        """
+
+            """
                 .trimIndent()
         )
 
@@ -112,8 +112,8 @@ class WarningsAndErrorsTest {
             """
             # SPDX-License-Identifier: Apache-2.0
             jdk=17.0.99
-            
-        """
+
+            """
                 .trimIndent()
         )
 
@@ -123,5 +123,28 @@ class WarningsAndErrorsTest {
             .content()
             .contains("This project works best running with Java 17.0.99")
             .contains("'Gradle JVM' in 'Gradle Settings'")
+    }
+
+    @Test
+    fun `throws warning as error for --warning-mode=fail`() {
+        val p = GradleProject()
+        p.withMinimalStructure().withWarningMode("fail")
+
+        val out = p.failQualityCheck().output
+
+        assertThat(out)
+            .contains(
+                """
+                > Failed to apply plugin 'org.hiero.gradle.feature.build-cache'.
+                   > Build Cache Disabled
+                       Build Cache Disabled
+                         Location: gradle.properties
+
+                * Try:
+                > Add org.gradle.caching=true to gradle.properties
+                > For more information, see https://github.com/hiero-ledger/hiero-gradle-conventions#project-structure
+                """
+                    .trimIndent()
+            )
     }
 }

--- a/src/test/kotlin/org/hiero/gradle/test/fixtures/GradleProject.kt
+++ b/src/test/kotlin/org/hiero/gradle/test/fixtures/GradleProject.kt
@@ -33,6 +33,8 @@ class GradleProject(
 
     private val env = mutableMapOf<String, String>()
 
+    private var warningMode = "all"
+
     fun withMinimalStructure(): GradleProject {
         gradlePropertiesFile.writeText(
             """
@@ -82,6 +84,11 @@ class GradleProject(
     fun withEnv(env: Map<String, String>): GradleProject {
         this.env["PATH"] = System.getenv("PATH") // some plugins use low-level commands like 'uname'
         this.env.putAll(env)
+        return this
+    }
+
+    fun withWarningMode(mode: String): GradleProject {
+        this.warningMode = mode
         return this
     }
 
@@ -151,7 +158,7 @@ class GradleProject(
             .forwardOutput()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments(args + listOf("-s", "--warning-mode=all"))
+            .withArguments(args + listOf("-s", "--warning-mode=$warningMode"))
             .withDebug(debugMode)
             .let { if (env.isEmpty() || debugMode) it else it.withEnvironment(env) }
     }


### PR DESCRIPTION
**Description**:

With this, we can add `--warning-mode=fail` to CI builds to avoid running into inconsistencies, such as inconsistent Java version configuration, in the future.

**Related issue(s)**:

Resolves #486 
